### PR TITLE
fix: user별 피드 목록 api 경로 수정

### DIFF
--- a/src/services/feed/index.ts
+++ b/src/services/feed/index.ts
@@ -15,7 +15,7 @@ const FeedService = {
     username: string | string[] | undefined,
     listData?: FeedListType,
   ) => {
-    const { data } = await api.get(`/feed/${username}`, {
+    const { data } = await api.get(`/feed/user/${username}`, {
       params: {
         ...listData,
       },


### PR DESCRIPTION
## 🐳 개요
유저별 피드 목록 api 경로 수정 
## 🐳 작업사항
- 기존 
```tsx
 const { data } = await api.get(`/feed/${username}`, {
      params: {
        ...listData,
      },
    });
```
- 변경
```tsx
  const { data } = await api.get(`/feed/user/${username}`, {
      params: {
        ...listData,
      },
    });
```

## 🐳 공유사항
- 서버 쪽도 dev 브랜치 pull 하셔야 제대로 동작합니다 

