### PR TITLE
fix: localstorage 에러 수정, useLayoutEffect 공유사항

### DIFF
--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,19 +1,21 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
-export const useLocalStorage = <T>(key: string, initialValue: T) => {
-  const [storedValue, setStoredValue] = useState(() => {
+export const useLocalStorage = <T>(
+  key: string,
+  initialValue: T,
+): [T, (value: T) => void] => {
+  const [storedValue, setStoredValue] = useState(initialValue);
+
+  useEffect(() => {
     try {
       const item = window.localStorage.getItem(key);
-      return item
-        ? typeof item === 'object'
-          ? JSON.parse(item)
-          : item
-        : initialValue;
+      if (item) {
+        setStoredValue(typeof item === 'object' ? JSON.parse(item) : item);
+      }
     } catch (error) {
       console.error(error);
-      return initialValue;
     }
-  });
+  }, [key]);
 
   const setValue = (value: T) => {
     try {


### PR DESCRIPTION
## 🐳 개요

- 로컬 스토리지 window is not defined 에러 수정
- useLayoutEffect 에러 관련 공유사항

## 🐳 작업사항

* Next.js 서버 렌더링시, window 코드를 만나면 읽지 못한다.
그래서 해당 객체는 'undefind'로 결정되고 이는 전체 로직에 문제를 야기할 수 있다.

해당 문제가 발생하는 위치는 useLocalStorage 커스텀 훅이였고

window 코드가 담긴 부분을 클라이언트에서만 동작할 수 있도록 하기 위해

useEffect를 만들고 해당 코드들을  그 안에다가 넣었다.

```ts
const [storedValue, setStoredValue] = useState(() => {
    try {
      const item = window.localStorage.getItem(key);
      return item
        ? typeof item === 'object'
          ? JSON.parse(item)
          : item
        : initialValue;
    } catch (error) {
      console.error(error);
      return initialValue;
    }
  });
```
이전 코드

```ts
const [storedValue, setStoredValue] = useState(initialValue);

  useEffect(() => {
    try {
      const item = window.localStorage.getItem(key);
      if (item) {
        setStoredValue(typeof item === 'object' ? JSON.parse(item) : item);
      }
    } catch (error) {
      console.error(error);
    }
  }, [key]);
```
이제 window는 useEffect 가 동작할때만 실행되므로 서버에서 동작할 수 없다.
근데 useLocalStorage 커스텀 훅이 서버에서 호출되는 코드를 찾아볼 수 없는데 대체 어디서 서버 호출을 했다는건지는 파악하지 못했다.

## 🐳 공유사항

*![image](https://github.com/PlaNet-Devteam/sns-project-client/assets/101001956/c5a3f18a-3ccf-449f-a88a-499c236ed5b3)

해당 메시지는 Next.js 환경에서 useLayoutEffect 가 사용되면 무조건 터미널에 출력되는 경고 메시지이다.

리액트 측에서 일종의 경고 메시지를 보내는 것으로, '에러'가 아닌 말 그대로 '경고'이다.

진짜 에러는 서버 컴포넌트에 useLayoutEffect 를 사용했을 때, 발생하는게 진짜 에러이다. 이러면 콘솔에 출력된다.

