### PR TITLE
feat: feed 수정기능 구현

### DIFF
--- a/src/components/feed/FeedItem.tsx
+++ b/src/components/feed/FeedItem.tsx
@@ -4,11 +4,13 @@ import { useRouter } from 'next/router';
 import Link from 'next/link';
 import { BsThreeDotsVertical } from 'react-icons/bs';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useSetRecoilState } from 'recoil';
 import { FeedType } from '@/core/types/feed';
 import FeedImg from '@/components/feed/FeedImg';
 import FeedService from '@/services/feed';
 import { formattedDate } from '@/utils/formattedDate';
 import useAuth from '@/hooks/useAuth';
+import { feedState } from '@/store/feedAtom';
 import { useLocalStorage } from '../../hooks/useLocalStorage';
 import Dialog from '../dialog/Dialog';
 import LoadingLayer from '../common/LoadingLayer';
@@ -22,6 +24,7 @@ interface FeedItemProps {
 const FeedItem = ({ item }: FeedItemProps) => {
   const queryClient = useQueryClient(); // TODO: 체크
   const { payload } = useAuth();
+  const setFeedModifyState = useSetRecoilState(feedState);
 
   const [imgSrc, setImgSrc] = useState(
     `${process.env.NEXT_PUBLIC_AWS_S3_BUCKET}${item.user?.profileImage}`,
@@ -50,6 +53,11 @@ const FeedItem = ({ item }: FeedItemProps) => {
 
   const handleDeleteFeedItem = async (feedId: number) => {
     deleteFeedItemMutation.mutate(feedId);
+  };
+
+  const handleModifyFeedItem = async (item: FeedType) => {
+    setFeedModifyState(item);
+    router.replace('/feed/modify');
   };
 
   const openModalIfImgCnt = () => {
@@ -138,7 +146,12 @@ const FeedItem = ({ item }: FeedItemProps) => {
       <Dialog isOpen={isModalOpen}>
         <Dialog.Dimmed onClick={handleModalOpen} />
         {item.user.username === payload?.username && (
-          <Dialog.LabelButton color="white">수정</Dialog.LabelButton>
+          <Dialog.LabelButton
+            color="white"
+            onClick={() => handleModifyFeedItem(item)}
+          >
+            수정
+          </Dialog.LabelButton>
         )}
         {item.user.username === payload?.username && (
           <Dialog.LabelButton

--- a/src/core/types/feed/feed-image.interface.ts
+++ b/src/core/types/feed/feed-image.interface.ts
@@ -1,6 +1,6 @@
 export interface FeedImageType {
-  secIndex: number;
-  firIndex: number;
+  secIndex?: number;
+  firIndex?: number;
   feedId?: number;
   sortOrder: number;
   image: string;

--- a/src/core/types/feed/feed-modify.interface.ts
+++ b/src/core/types/feed/feed-modify.interface.ts
@@ -1,0 +1,6 @@
+import { FeedImageType } from './feed-image.interface';
+
+export interface FeedModifyType {
+  description?: string;
+  feedImages?: FeedImageType[];
+}

--- a/src/pages/feed/modify/index.tsx
+++ b/src/pages/feed/modify/index.tsx
@@ -1,0 +1,185 @@
+import Image from 'next/image';
+import { useRef, useState } from 'react';
+import { TiDelete } from 'react-icons/ti';
+import { AiOutlineCamera } from 'react-icons/ai';
+import { useRouter } from 'next/router';
+import { useMutation } from '@tanstack/react-query';
+import { FormEvent } from 'react';
+import { useRecoilValue } from 'recoil';
+import { uploadFile } from '@/utils/uploadImage';
+import FeedHeader from '@/components/feed/FeedHeader';
+import { FeedImageType } from '@/core/types/feed';
+import useForm from '@/hooks/useForm';
+import FeedService from '@/services/feed';
+import Button from '@/components/common/Button';
+import useMouseDrag from '@/hooks/useMouseDrag';
+import { feedState } from '@/store/feedAtom';
+import { FeedModifyType } from '@/core/types/feed/feed-modify.interface';
+
+function ModifyFeed() {
+  const router = useRouter();
+  const feedItem = useRecoilValue(feedState);
+  const [imageList, setImageList] = useState<FeedImageType[]>(
+    feedItem?.feedImages || [],
+  );
+  const orderIndex = useRef<number>(0);
+  const scrollRef = useRef<any>(null);
+  const { isDrag, onDragStart, onDragEnd, onThrottleDragMove } =
+    useMouseDrag(scrollRef);
+  const { formData: feedModify, onChange } = useForm<FeedModifyType>({
+    description: feedItem?.description || '',
+    feedImages: imageList,
+  });
+
+  const { mutateAsync } = useMutation((formData: FeedModifyType) =>
+    FeedService.modifyFeed(feedItem?.id || 0, formData),
+  );
+
+  const onSubmitForm = async (
+    event: FormEvent<HTMLFormElement>,
+    formData: FeedModifyType,
+  ) => {
+    event.preventDefault();
+
+    if (imageList?.length === 0) {
+      alert('사진을 첨부해주세요.');
+      return;
+    }
+
+    try {
+      let list: FeedImageType[] = [];
+      for (let i = 0; i < imageList.length; i++) {
+        const result: FeedImageType = {
+          feedId: feedItem?.id,
+          sortOrder: orderIndex.current++,
+          image: imageList[i].image,
+        };
+        list = [...list, result];
+      }
+      console.log(list);
+      await mutateAsync({
+        ...formData,
+        feedImages: list,
+      });
+      router.push('/feed');
+      setImageList([]);
+    } catch (error: any) {
+      console.log('error?.response', error?.response);
+    }
+
+    console.log('imageList', imageList);
+  };
+
+  const onClickUploadImageHandler = async (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const imageLists = event.target.files || [];
+
+    let imageUrlLists = [...imageList];
+
+    for (let i = 0; i < imageLists.length; i++) {
+      const currentImageUrl = await uploadFile(imageLists[i], 'feed');
+      const result: FeedImageType = {
+        feedId: feedItem?.id,
+        sortOrder: 0,
+        image: currentImageUrl as string,
+      };
+      imageUrlLists = [...imageUrlLists, result];
+    }
+
+    if (imageUrlLists.length > 5) {
+      imageUrlLists = imageUrlLists.slice(0, 5);
+
+      alert('최대 5장까지 가능합니다.');
+    }
+
+    setImageList(imageUrlLists);
+    console.log(imageList);
+  };
+
+  const onClickRemoveImageHandler = (index: number) => {
+    setImageList((prev) => prev.filter((_, idx) => idx !== index));
+  };
+
+  return (
+    <div className="feed-create">
+      <div className="feed-create-form inner__container">
+        <FeedHeader title="새 게시물" />
+
+        <div className="feed-create-form-input">
+          <div className="feed-create-form-input__label">
+            <label
+              htmlFor="file"
+              className="button button-size--sm button-bg--ghost button-text--english"
+            >
+              <AiOutlineCamera
+                size={24}
+                className="feed-create-form-input__button-icon"
+              />
+              사진첨부하기
+            </label>
+          </div>
+          <input
+            id="file"
+            type="file"
+            accept="image/*"
+            multiple={true}
+            className="feed-create-form-input__input"
+            onInput={onClickUploadImageHandler}
+          />
+        </div>
+        <div
+          className="feed-create-form-image-upload"
+          onMouseDown={onDragStart}
+          onMouseUp={onDragEnd}
+          onMouseLeave={onDragEnd}
+          onMouseMove={isDrag ? onThrottleDragMove : undefined}
+          ref={(e) => (scrollRef.current = e)}
+        >
+          {imageList &&
+            imageList.map((image, index) => (
+              <div className="feed-create-form-image">
+                <div className="feed-create-form-image__button--delete">
+                  <button onClick={() => onClickRemoveImageHandler(index)}>
+                    <TiDelete size={24} color="black" />
+                  </button>
+                </div>
+                <div className="feed-create-form-image-upload__image">
+                  <Image
+                    src={`${process.env.NEXT_PUBLIC_AWS_S3_BUCKET}${image.image}`}
+                    key={image.sortOrder}
+                    width={100}
+                    height={100}
+                    alt="image"
+                  />
+                </div>
+              </div>
+            ))}
+        </div>
+        <form
+          className="feed-create-form-content"
+          onSubmit={(event) => onSubmitForm(event, feedModify)}
+        >
+          <textarea
+            className="feed-create-form__textarea"
+            name="description"
+            placeholder="내용을 입력해주세요."
+            value={feedModify.description}
+            onChange={onChange}
+          />
+          <Button
+            size="md"
+            variant="primary"
+            type="submit"
+            isEnglish
+            isFull
+            className="feed-create-form-complete__button"
+          >
+            완료
+          </Button>
+        </form>
+      </div>
+    </div>
+  );
+}
+export default ModifyFeed;

--- a/src/services/feed/index.ts
+++ b/src/services/feed/index.ts
@@ -1,5 +1,6 @@
 import { api } from '@/core/base.service';
 import { FeedCreateType, FeedListType } from '@/core/types/feed';
+import { FeedModifyType } from '@/core/types/feed/feed-modify.interface';
 
 const FeedService = {
   getFeeds: async (listData?: FeedListType) => {
@@ -25,6 +26,10 @@ const FeedService = {
   createFeed: async (formData: FeedCreateType) => {
     const { data } = await api.post('/feed', formData);
     return data.data;
+  },
+  modifyFeed: async (feedId: number, feedItem: FeedModifyType) => {
+    const { data } = await api.patch(`/feed/${feedId}`, feedItem);
+    return data;
   },
   deleteFeed: async (feedId: number) => {
     const { data } = await api.delete(`/feed/${feedId}`);

--- a/src/store/feedAtom.ts
+++ b/src/store/feedAtom.ts
@@ -1,5 +1,6 @@
 import { atom } from 'recoil';
-import { FeedImageType } from '@/core/types/feed';
+import { FeedImageType, FeedType } from '@/core/types/feed';
+import { FeedModifyType } from '@/core/types/feed/feed-modify.interface';
 
 // const feedImageState = atom<FeedImageType[]>({
 //   key: 'feedImageState',
@@ -11,4 +12,9 @@ const feedImageState = atom<number>({
   default: 0,
 });
 
-export { feedImageState };
+const feedState = atom<FeedType | null>({
+  key: 'feedState',
+  default: null,
+});
+
+export { feedImageState, feedState };


### PR DESCRIPTION
## 🐳 개요
- feed 수정기능 구현

## 🐳 작업사항

* 수정하고 싶은 피드 데이터 불러오기 및 수정
<img src="https://github.com/PlaNet-Devteam/sns-project-client/assets/96197310/63847b53-2c1a-4e0d-993e-81efd970434a" width="300px" height="600px">

<br />

* feedAtom에 feedState 추가
```
import { atom } from 'recoil';
import { FeedImageType, FeedType } from '@/core/types/feed';
import { FeedModifyType } from '@/core/types/feed/feed-modify.interface';


const feedImageState = atom<number>({
  key: 'feedImageState',
  default: 0,
});

const feedState = atom<FeedType | null>({
  key: 'feedState',
  default: null,
});

export { feedImageState, feedState };
```

## 🐳 공유사항

*  이미지 수정하는 부분을 구현하는게 좀 까다로워서 일단 글 먼저 수정할 수 있도록 구현하였습니다.
 feed.repository.ts에서 업데이트 부분 이런식으로 주석처리하시면 수정 기능 테스트해보실 수 있어요!

<img src="https://github.com/PlaNet-Devteam/sns-project-client/assets/96197310/975dcae0-e1a8-4470-94ad-cecba146fde0" width="500px" height="500px">

