### PR TITLE
fix: 날짜 오류 수정

### DIFF
--- a/src/utils/formattedDate.ts
+++ b/src/utils/formattedDate.ts
@@ -6,7 +6,7 @@ dayjs.locale('ko');
 
 export const formattedDate = () => {
   const setConvertTime = (time: string | undefined) => {
-    return dayjs(time).add(9, 'h').fromNow();
+    return dayjs(time).fromNow();
   };
 
   const dayDiff = (time: string | undefined) => {


### PR DESCRIPTION
## 🐳 개요

날짜 오류 수정

## 🐳 작업사항

* dayjs 처음 적용당시 날짜가 국제 표준시로 등록이 되었었는데, 이에 맞춰서 한국 시간에 맞추기 위해 국제 표준시 (UTC) + 9시간으로 적용했었습니다. 근데 날짜 등록 방식이 최근에 변경된 것 같습니다.
* + 9시간 코드를 삭제했습니다.

적용 전
```ts
export const formattedDate = () => {
  const setConvertTime = (time: string | undefined) => {
    return dayjs(time).add(9, 'h').fromNow();
  };

  const dayDiff = (time: string | undefined) => {
    if (dayjs().diff(time) > 8) {
      return setConvertTime(time);
    }
    return dayjs(time).format('YYYY년 M월 D일');
  };
  return 
```
적용 후
```ts
export const formattedDate = () => {
  const setConvertTime = (time: string | undefined) => {
    return dayjs(time).fromNow();
  };

  const dayDiff = (time: string | undefined) => {
    if (dayjs().diff(time) > 8) {
      return setConvertTime(time);
    }
    return dayjs(time).format('YYYY년 M월 D일');
  };
  return 
```

## 🐳 공유사항

* 
