### PR TITLE
refactor: useState 리팩토링

### DIFF
--- a/src/components/comment/CommentInput.tsx
+++ b/src/components/comment/CommentInput.tsx
@@ -67,13 +67,23 @@ const CommentInput = () => {
   return (
     <>
       <div className="comment__input">
-        <Image
-          className="comment__profile-image"
-          width={100}
-          height={100}
-          src={`${process.env.NEXT_PUBLIC_AWS_S3_BUCKET}${user?.profileImage}`}
-          alt="profile"
-        ></Image>
+        <div className="comment__profile-image">
+          {user?.profileImage ? (
+            <Image
+              width={100}
+              height={100}
+              src={`${process.env.NEXT_PUBLIC_AWS_S3_BUCKET}${user?.profileImage}`}
+              alt="profile"
+            ></Image>
+          ) : (
+            <Image
+              src={'/img/icons/icon_default_profile.svg'}
+              width={100}
+              height={100}
+              alt="프로필 이미지"
+            />
+          )}
+        </div>
         <form
           onSubmit={(event) => onSubmitForm(event, commentCreate)}
           className="comment__form"

--- a/src/components/comment/CommentItem.tsx
+++ b/src/components/comment/CommentItem.tsx
@@ -51,15 +51,25 @@ const CommentItem = ({ item }: CommentPropsType) => {
   return (
     <>
       <div className="comment">
-        <Link href={`/${item.user.username}`}>
-          <Image
-            className="comment__profile-image"
-            width={60}
-            height={60}
-            quality={100}
-            src={`${process.env.NEXT_PUBLIC_AWS_S3_BUCKET}${item.user?.profileImage}`}
-            alt="profile"
-          ></Image>
+        <Link
+          href={`/${item.user.username}`}
+          className="comment__profile-image"
+        >
+          {item.user?.profileImage ? (
+            <Image
+              width={100}
+              height={100}
+              src={`${process.env.NEXT_PUBLIC_AWS_S3_BUCKET}${item.user?.profileImage}`}
+              alt="profile"
+            ></Image>
+          ) : (
+            <Image
+              src={'/img/icons/icon_default_profile.svg'}
+              width={100}
+              height={100}
+              alt="프로필 이미지"
+            />
+          )}
         </Link>
         <div className="comment__info">
           <div className="comment__info-top">

--- a/src/components/feed/FeedItem.tsx
+++ b/src/components/feed/FeedItem.tsx
@@ -33,9 +33,6 @@ const FeedItem = ({ item }: FeedItemProps) => {
   const [_, setScrollY] = useLocalStorage('scroll_location', 0);
   const [isImgModalOpen, setIsImgModalOpen] = useState(false);
   const router = useRouter();
-  const handlecommentbutton = () => {
-    router.push(`/feed/${item.id}/comment`);
-  };
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const handleModalOpen = () => {
@@ -166,13 +163,9 @@ const FeedItem = ({ item }: FeedItemProps) => {
               <AiOutlineLike color="white" size={'1.5rem'} />
             )}
           </button>
-          <button className="subscription_icon">
-            <img
-              src="/comment.svg"
-              alt="comment"
-              onClick={handlecommentbutton}
-            />
-          </button>
+          <Link href={`/feed/${item.id}/comment`} className="subscription_icon">
+            <img src="/comment.svg" alt="comment" />
+          </Link>
           <img className="subscription_icon" src="/share.svg" alt="share" />
         </div>
       </div>

--- a/src/components/layouts/BaseLayout.tsx
+++ b/src/components/layouts/BaseLayout.tsx
@@ -1,21 +1,49 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useRouter } from 'next/router';
-import { useRecoilValue } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { useQuery } from '@tanstack/react-query';
 import { BaseProps } from '@/core/types/common';
 import { userState } from '@/store/userAtom';
-import { UserType } from '@/core';
+import { AxiosErrorResponseType, UserType } from '@/core';
+import useAuth from '@/hooks/useAuth';
+import UserService from '@/services/user';
+import { profileState } from '@/store/profileAtom';
 import BottomNav from '../nav/bottomNav/BottomNav';
 
 const BaseLayout = ({ children }: BaseProps) => {
-  const user = useRecoilValue<UserType | null>(userState);
+  const router = useRouter();
+  const { payload } = useAuth();
+  const [user, setUser] = useRecoilState<UserType | null>(userState);
+  const profile = useRecoilValue<UserType | null>(profileState);
+
+  const { data: userInfo } = useQuery(
+    ['user', payload?.username],
+    () => {
+      if (payload?.username === 'undefined') return router.push('/login');
+      return UserService.findUserByUsername(payload?.username as string);
+    },
+    {
+      onError: (error: AxiosErrorResponseType) => {
+        if (error?.response?.status === 404) {
+          alert(error?.response?.data.message);
+        }
+        router.push('/_error');
+      },
+    },
+  );
 
   const isVisibleRoutes = [
     '/feed',
     `/${user?.username}`,
     `/${user?.username}/bookmark`,
+    `/${profile?.username}`,
     '/explore',
   ];
   const { asPath } = useRouter();
+
+  useEffect(() => {
+    setUser(userInfo);
+  }, [userInfo, setUser]);
 
   return (
     <main className="app-main">

--- a/src/components/layouts/ProfileLayout.tsx
+++ b/src/components/layouts/ProfileLayout.tsx
@@ -4,9 +4,9 @@ import { useSetRecoilState } from 'recoil';
 import { useQuery } from '@tanstack/react-query';
 import { BaseProps } from '@/core/types/common';
 import UserService from '@/services/user';
-import { userState } from '@/store/userAtom';
 import { AxiosErrorResponseType } from '@/core/types/error/axios-error-response.type';
 import useAuth from '@/hooks/useAuth';
+import { profileState } from '@/store/profileAtom';
 import ProfileInfo from '../profile/ProfileInfo';
 import ProfileCount from '../profile/ProfileCount';
 import ProfileFeedTabs from '../profile/ProfileFeedTabs';
@@ -16,15 +16,13 @@ import TopHeader from '../nav/topHeader/TopHeader';
 const ProfileLayout = ({ children }: BaseProps) => {
   const router = useRouter();
   const { payload, onLogout } = useAuth();
-  const setUser = useSetRecoilState(userState);
+  const setProfie = useSetRecoilState(profileState);
 
   const { data: profile } = useQuery(
     ['user', router.query.username],
     () => {
       if (router.query.username === 'undefined') return router.push('/login');
-      return UserService.findUserByUsername(
-        (router.query.username as string) || (payload?.username as string),
-      );
+      return UserService.findUserByUsername(router.query.username as string);
     },
     {
       onError: (error: AxiosErrorResponseType) => {
@@ -41,8 +39,8 @@ const ProfileLayout = ({ children }: BaseProps) => {
   };
 
   useEffect(() => {
-    setUser(profile);
-  }, [profile, setUser]);
+    setProfie(profile);
+  }, [profile, setProfie]);
 
   return (
     <>

--- a/src/components/profile/ProfileFeedTabs.tsx
+++ b/src/components/profile/ProfileFeedTabs.tsx
@@ -1,24 +1,30 @@
 import React from 'react';
 import { useRecoilValue } from 'recoil';
+import { useRouter } from 'next/router';
 import IconBookmark from '@/assets/icons/icon_bookmark.svg';
 import IconFeed from '@/assets/icons/icon_feed.svg';
 import { userState } from '@/store/userAtom';
 import { UserType } from '@/core';
+import useAuth from '@/hooks/useAuth';
+import { profileState } from '@/store/profileAtom';
 import ProfileFeedTabItem from './ProfileFeedTabItem';
 
 function ProfileFeedTabs() {
   const user = useRecoilValue<UserType | null>(userState);
+  const profile = useRecoilValue<UserType | null>(profileState);
 
   return (
     <>
-      {user && (
+      {profile && (
         <div className="profile-feeds-tabs">
-          <ProfileFeedTabItem path={`/${user.username}`}>
+          <ProfileFeedTabItem path={`/${profile?.username}`}>
             <IconFeed />
           </ProfileFeedTabItem>
-          <ProfileFeedTabItem path={`/${user.username}/bookmark`}>
-            <IconBookmark />
-          </ProfileFeedTabItem>
+          {profile?.username === user?.username && (
+            <ProfileFeedTabItem path={`/${profile?.username}/bookmark`}>
+              <IconBookmark />
+            </ProfileFeedTabItem>
+          )}
         </div>
       )}
     </>

--- a/src/core/types/feed/feed-list.interface.ts
+++ b/src/core/types/feed/feed-list.interface.ts
@@ -1,4 +1,3 @@
-
 import { BaseListType } from '../common';
 
 export interface FeedListType extends BaseListType {

--- a/src/store/feedAtom.ts
+++ b/src/store/feedAtom.ts
@@ -1,11 +1,5 @@
 import { atom } from 'recoil';
-import { FeedImageType, FeedType } from '@/core/types/feed';
-import { FeedModifyType } from '@/core/types/feed/feed-modify.interface';
-
-// const feedImageState = atom<FeedImageType[]>({
-//   key: 'feedImageState',
-//   default: [],
-// });
+import { FeedType } from '@/core/types/feed';
 
 const feedImageState = atom<number>({
   key: 'feedImageState',

--- a/src/store/profileAtom.ts
+++ b/src/store/profileAtom.ts
@@ -1,0 +1,9 @@
+import { atom } from 'recoil';
+import { UserType } from '@/core';
+
+const profileState = atom<UserType | null>({
+  key: 'profileState',
+  default: null,
+});
+
+export { profileState };

--- a/src/styles/components/comment/_comment.scss
+++ b/src/styles/components/comment/_comment.scss
@@ -12,10 +12,14 @@
     width: 2.5rem;
     height: 2.5rem;
     border-radius: var(--border-radius-xl);
-    justify-self: center;
-    align-self: flex-start;
     margin: 0.25rem;
     cursor: pointer;
+    overflow: hidden;
+    background-color: white;
+    img {
+      width:100%;
+      height:100%;
+    }
   }
   .comment__isLike {
     font-size: var(--font-size-xs);

--- a/src/styles/components/comment/_input.scss
+++ b/src/styles/components/comment/_input.scss
@@ -16,6 +16,12 @@
     height: 2.5rem;
     border-radius: var(--border-radius-xl);
     margin-right: 1rem;
+    overflow: hidden;
+    background-color: white;
+    img {
+      width:100%;
+      height:100%;
+    }
   }
   .comment__form {
     display: flex;


### PR DESCRIPTION
## 🐳 개요
useState 리팩토링

## 🐳 작업사항
- BaseLayout 에서 userState 상태 관리 
-> 기존에는 프로필 페이지에서 유저정보를 가져옴 -
-> 다른 라우터에서 새로고침 됐을 경우   다시 유저정보를 가져오기 위해 레이아웃 단에서 유저정보 설정
- profileState 와 상태 분리 (프로필 메이지 정보 본인 뿐 아니라 다른 유저의 프로필 포함)

문제 예시 - 새로고침 했을때 코멘트 인풋창에 유저정보 리셋됨 
<img width="265" alt="20230922_182115" src="https://github.com/PlaNet-Devteam/sns-project-client/assets/52031484/563d0f9c-9859-4a5b-b8b0-33ea59f1499d">


## 🐳 공유사항
- 코드 상에서 공백에 관한 린트 에러가 있어서 push가 안되는 에러가있었습니다.
- 해당 브랜지까지 merge하면 dev에서 pull 받으시며 됩니다 

