### PR TITLE
fix: sockiet.io-client module 타입 선언

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,1 @@
+declare module 'socket.io-client';


### PR DESCRIPTION
## 🐳 개요
sockiet.io-client module 타입 선언

## 🐳 작업사항
```ts
// global.d.ts
declare module 'socket.io-client';
```

## 🐳 공유사항
타입정의 파일 사용하기 `~.d.ts` 
[참고 URL] 
- https://joshua1988.github.io/ts/usage/declaration.html
- https://velog.io/@jian09/d.ts-%ED%8C%8C%EC%9D%BC-%EC%9D%B4%EC%9A%A9%ED%95%98%EA%B8%B0
