### PR TITLE
feat: 계정 활성/비활성화 및 계정 삭제 기능  

### DIFF
--- a/src/components/common/ActivateUser.module.scss
+++ b/src/components/common/ActivateUser.module.scss
@@ -1,0 +1,7 @@
+.activate {
+  padding:2.5rem 0;
+  min-height:inherit;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/src/components/common/ActivateUser.tsx
+++ b/src/components/common/ActivateUser.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import dayjs from 'dayjs';
+import { useRecoilValue } from 'recoil';
+import { BiUserPin } from 'react-icons/bi';
+import { useMutation } from '@tanstack/react-query';
+import { userState } from '@/store/userAtom';
+import useAuth from '@/hooks/useAuth';
+import UserService from '@/services/user';
+import TypoText from './TypoText';
+import ButtonGroup from './ButtonGroup';
+import Button from './Button';
+import styles from './ActivateUser.module.scss';
+import LoadingSpinner from './LoadingSpinner';
+
+const ActivateUser = () => {
+  const myInfo = useRecoilValue(userState);
+  const { onLogout } = useAuth();
+
+  const { mutateAsync, isLoading } = useMutation({
+    mutationFn: () => UserService.activateUser(),
+    onSuccess: () => {
+      alert('계정 삭제 처리가 취소 되었습니다. 재로그인 해주세요');
+      onLogout();
+    },
+  });
+
+  const onClickActivateHandler = () => {
+    mutateAsync();
+  };
+
+  return (
+    <div className={styles.activate}>
+      <div className="inner__container">
+        <div className="text-center">
+          <BiUserPin size={'4rem'} color="white" />
+          <TypoText color="white" tagName="h3">
+            회원님은 현재 <br />
+            <TypoText color="success" tagName="span">
+              계정 삭제 처리 중
+            </TypoText>
+            입니다
+          </TypoText>
+          <br />
+          <br />
+          <TypoText color="white" tagName="h4">
+            계정 삭제 요청일 :&nbsp;
+            <TypoText color="success" tagName="span">
+              {dayjs(myInfo?.inactiveAt).format('YYYY년 M월 D일')}
+            </TypoText>
+          </TypoText>
+          <br />
+          <br />
+          <TypoText color="white" tagName="h5">
+            회원님은 요청일로부터 7일간의 유예기간 동안에만 <br />
+            계정 삭제 취소가 가능합니다
+          </TypoText>
+          <TypoText color="white" tagName="h5">
+            [계정 삭제 취소] 후에는 정상적인 서비스 이용을 <br />
+            위하여 다시 로그인 해주셔야 합니다
+          </TypoText>
+        </div>
+        <ButtonGroup>
+          <Button
+            variant="primary"
+            size="md"
+            isFull
+            onClick={onClickActivateHandler}
+          >
+            {isLoading ? (
+              <LoadingSpinner variant="white" />
+            ) : (
+              <> 계정 삭제 취소</>
+            )}
+          </Button>
+          <Button variant="secondary" size="md" isFull onClick={onLogout}>
+            돌아가기
+          </Button>
+        </ButtonGroup>
+      </div>
+    </div>
+  );
+};
+
+export default ActivateUser;

--- a/src/components/common/InactivatedUser.module.scss
+++ b/src/components/common/InactivatedUser.module.scss
@@ -1,0 +1,11 @@
+.inactivated_user {
+  text-align: center;
+  padding:5rem 1rem;
+  
+  svg {
+    width:5rem;
+    height:5rem;
+    margin-bottom: 1rem;
+  }
+
+}

--- a/src/components/common/InactivatedUser.tsx
+++ b/src/components/common/InactivatedUser.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
 import { BsFillShieldLockFill } from 'react-icons/bs';
 import Link from 'next/link';
+import { useRecoilStateLoadable, useRecoilValue } from 'recoil';
+import { userState } from '@/store/userAtom';
 import TypoText from './TypoText';
 import styles from './InactivatedUser.module.scss';
 
 const InactivatedUser = () => {
+  const myInfo = useRecoilValue(userState);
+
   return (
     <div className={styles.inactivated_user}>
       <BsFillShieldLockFill color="gray" />
@@ -12,9 +16,13 @@ const InactivatedUser = () => {
         비공개 계정입니다
         <br />
         피드를 보려면
-        <Link href="/login" className="text-link">
-          로그인 하세요
-        </Link>
+        {myInfo ? (
+          <> 팔로우하세요</>
+        ) : (
+          <Link href="/login" className="text-link">
+            로그인 하세요
+          </Link>
+        )}
       </TypoText>
     </div>
   );

--- a/src/components/common/InactivatedUser.tsx
+++ b/src/components/common/InactivatedUser.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { BsFillShieldLockFill } from 'react-icons/bs';
+import Link from 'next/link';
+import TypoText from './TypoText';
+import styles from './InactivatedUser.module.scss';
+
+const InactivatedUser = () => {
+  return (
+    <div className={styles.inactivated_user}>
+      <BsFillShieldLockFill color="gray" />
+      <TypoText tagName="p" color="gray">
+        비공개 계정입니다
+        <br />
+        피드를 보려면
+        <Link href="/login" className="text-link">
+          로그인 하세요
+        </Link>
+      </TypoText>
+    </div>
+  );
+};
+
+export default InactivatedUser;

--- a/src/components/common/InactivatedUser.tsx
+++ b/src/components/common/InactivatedUser.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { BsFillShieldLockFill } from 'react-icons/bs';
 import Link from 'next/link';
-import { useRecoilStateLoadable, useRecoilValue } from 'recoil';
+import { useRecoilValue } from 'recoil';
 import { userState } from '@/store/userAtom';
 import TypoText from './TypoText';
 import styles from './InactivatedUser.module.scss';

--- a/src/components/common/SwitchButton.module.scss
+++ b/src/components/common/SwitchButton.module.scss
@@ -1,0 +1,66 @@
+.item {
+  display:flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  + .item {
+    margin-top:1rem;
+  }
+}
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 60px;
+  height: 34px;
+
+  input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+    &:checked,
+    &:focus {
+      + .slider {
+        background-color: var(--secondary-color);
+        &:before {
+          -webkit-transform: translateX(26px);
+          -ms-transform: translateX(26px);
+          transform: translateX(26px);
+        }
+      }
+    }
+  }
+
+  .slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #ccc;
+    -webkit-transition: .4s;
+    transition: .4s;
+    border-radius: 34px;
+
+    &:before {
+      position: absolute;
+      content: "";
+      height: 26px;
+      width: 26px;
+      left: 4px;
+      bottom: 4px;
+      background-color: white;
+      -webkit-transition: .4s;
+      transition: .4s;
+      border-radius: 50%;
+    }
+    
+  }
+}  
+
+
+
+
+
+
+

--- a/src/components/common/SwitchButton.tsx
+++ b/src/components/common/SwitchButton.tsx
@@ -1,0 +1,59 @@
+import React, { ChangeEvent, Dispatch, useState } from 'react';
+import styles from './SwitchButton.module.scss';
+import TypoText from './TypoText';
+
+interface SwitchButtonProps {
+  id?: string;
+  defaultChecked?: boolean;
+  checked?: boolean;
+  readOnly?: boolean;
+  label?: string;
+  onClick?: () => void;
+}
+
+const SwitchButton = ({
+  id,
+  readOnly,
+  defaultChecked,
+  label,
+  onClick,
+}: SwitchButtonProps) => {
+  const [checked, setChecked] = useState(defaultChecked);
+  const onChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setChecked(event.target.checked);
+  };
+
+  const InputElement = () => {
+    if (readOnly) {
+      return (
+        <input
+          type="checkbox"
+          defaultChecked={defaultChecked}
+          readOnly={true}
+        />
+      );
+    } else {
+      return (
+        <input type="checkbox" checked={checked} onChange={onChange} id={id} />
+      );
+    }
+  };
+
+  return (
+    <>
+      <label className={styles.item} onClick={onClick} htmlFor={id}>
+        <label className={styles.label}>
+          <TypoText tagName="p" color="white">
+            {label}
+          </TypoText>
+        </label>
+        <div className={styles.switch}>
+          <InputElement />
+          <div className={styles.slider}></div>
+        </div>
+      </label>
+    </>
+  );
+};
+
+export default SwitchButton;

--- a/src/components/common/TypoText.module.scss
+++ b/src/components/common/TypoText.module.scss
@@ -1,0 +1,46 @@
+.text {
+  + .text {
+    margin-top:0.5rem;
+  }
+
+  line-height: 1.6;
+
+
+  &.primary {
+    color: var(--primary-color);
+  }
+
+  &.secondary {
+    color: var(--secondary-color);
+  }
+
+  &.success {
+    color: var(--success-color);
+  }
+
+  &.warning {
+    color: var(--warning-color);
+  }
+
+  &.danger {
+    color: var(--danger-color);
+  }
+
+  &.essential {
+    color: var(--essential-color);
+  }
+
+  &.black {
+    color: var(--black);
+  }
+
+  &.white {
+    color: var(--white);
+  }
+
+  &.gray {
+    color: var(--gray);
+  }
+  
+}
+

--- a/src/components/common/TypoText.tsx
+++ b/src/components/common/TypoText.tsx
@@ -17,10 +17,14 @@ interface ColorType {
 
 interface TypoTextProps extends BaseProps {
   color?: keyof ColorType;
-  tagName: keyof JSX.IntrinsicElements;
+  tagName?: keyof JSX.IntrinsicElements;
 }
 
-const TypoText = ({ color = 'black', tagName, children }: TypoTextProps) => {
+const TypoText = ({
+  color = 'black',
+  tagName = 'p',
+  children,
+}: TypoTextProps) => {
   const Element = tagName;
 
   return (

--- a/src/components/common/TypoText.tsx
+++ b/src/components/common/TypoText.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import classnames from 'classnames';
+import { BaseProps } from '@/core/types/common';
+import styles from './TypoText.module.scss';
+
+interface ColorType {
+  primary: string;
+  secondary: string;
+  essential: string;
+  warning: string;
+  success: string;
+  danger: string;
+  gray: string;
+  white: string;
+  black: string;
+}
+
+interface TypoTextProps extends BaseProps {
+  color?: keyof ColorType;
+  tagName: keyof JSX.IntrinsicElements;
+}
+
+const TypoText = ({ color = 'black', tagName, children }: TypoTextProps) => {
+  const Element = tagName;
+
+  return (
+    <Element
+      className={classnames(styles.text, styles[color as keyof ColorType])}
+    >
+      {children}
+    </Element>
+  );
+};
+
+export default TypoText;

--- a/src/components/dialog/Dialog.tsx
+++ b/src/components/dialog/Dialog.tsx
@@ -4,16 +4,14 @@ import { BaseProps } from '@/core/types/common';
 import DialogLabelButton from './DialogLabelButton';
 import styles from './Dialog.module.scss';
 import DialogDimmed from './DialogDimmed';
+import DialogContent from './DialogContent';
 
-// * 라벨버튼은 최대 2개만 가져오기
 const DialogLabelButtonType = (<DialogLabelButton />).type;
 function getDialogLabelButtons(children: ReactNode) {
   const childrenArray = Children.toArray(children);
-  return childrenArray
-    .filter(
-      (child) => isValidElement(child) && child.type === DialogLabelButtonType,
-    )
-    .slice(0, 2);
+  return childrenArray.filter(
+    (child) => isValidElement(child) && child.type === DialogLabelButtonType,
+  );
 }
 
 const DialogDimmedTye = (<DialogDimmed />).type;
@@ -28,11 +26,21 @@ interface DialogMainProps extends BaseProps {
   isOpen: boolean;
 }
 
+const DialogContentType = (<DialogContent />).type;
+function getDialogContent(children: ReactNode) {
+  const childrenArray = Children.toArray(children);
+  return childrenArray
+    .filter(
+      (child) => isValidElement(child) && child.type === DialogContentType,
+    )
+    .slice(0, 1);
+}
+
 const DialogMain = ({ children, isOpen }: DialogMainProps) => {
   if (!isOpen) {
     return null;
   }
-
+  const dialogContent = getDialogContent(children);
   const dialogLabelButtons = getDialogLabelButtons(children);
   const dialogDimmed = getDialogDimmed(children);
 
@@ -41,7 +49,10 @@ const DialogMain = ({ children, isOpen }: DialogMainProps) => {
       {dialogLabelButtons && (
         <div className={styles.container}>
           {dialogDimmed}
-          <div className={styles.dialog}>{dialogLabelButtons}</div>
+          <div className={styles.dialog}>
+            {dialogContent}
+            {dialogLabelButtons}
+          </div>
         </div>
       )}
     </div>,
@@ -52,6 +63,7 @@ const DialogMain = ({ children, isOpen }: DialogMainProps) => {
 const Dialog = Object.assign(DialogMain, {
   LabelButton: DialogLabelButton,
   Dimmed: DialogDimmed,
+  Content: DialogContent,
 });
 
 export default Dialog;

--- a/src/components/dialog/DialogContent.module.scss
+++ b/src/components/dialog/DialogContent.module.scss
@@ -1,0 +1,5 @@
+.content {
+  padding: 2.5rem 1rem;
+  color: white;
+  border-bottom: 1px solid rgba($color: white, $alpha: 0.1);
+}

--- a/src/components/dialog/DialogContent.tsx
+++ b/src/components/dialog/DialogContent.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { BaseProps } from '@/core/types/common';
+import styles from './DialogContent.module.scss';
+
+const DialogContent = ({ children }: BaseProps) => {
+  return <div className={styles.content}>{children}</div>;
+};
+
+export default DialogContent;

--- a/src/components/follow/FollowListItem.tsx
+++ b/src/components/follow/FollowListItem.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import { FiUserPlus, FiTrash, FiUserMinus } from 'react-icons/fi';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRecoilValue } from 'recoil';
-import Link from 'next/link';
 import { FollowCreateType, FollowType } from '@/core/types/follow';
 import { FOLLOW, UserType } from '@/core';
 import FollowService from '@/services/follow';
@@ -98,7 +97,6 @@ const FollowListItem = ({ queryKey, item, user }: FollowListItemProps) => {
                   <>
                     <Button
                       variant="primary"
-                      isFull={true}
                       isEnglish={true}
                       iconOnly
                       size="sm"
@@ -111,7 +109,6 @@ const FollowListItem = ({ queryKey, item, user }: FollowListItemProps) => {
                   <>
                     <Button
                       variant="gray"
-                      isFull={true}
                       isEnglish={true}
                       iconOnly
                       size="sm"
@@ -128,7 +125,6 @@ const FollowListItem = ({ queryKey, item, user }: FollowListItemProps) => {
                   <>
                     <Button
                       variant="primary"
-                      isFull={true}
                       isEnglish={true}
                       iconOnly
                       size="sm"
@@ -138,13 +134,7 @@ const FollowListItem = ({ queryKey, item, user }: FollowListItemProps) => {
                     </Button>
                   </>
                 )}
-                <Button
-                  variant="gray"
-                  isFull={true}
-                  isEnglish={true}
-                  iconOnly
-                  size="sm"
-                >
+                <Button variant="gray" isEnglish={true} iconOnly size="sm">
                   <FiTrash />
                 </Button>
               </>

--- a/src/components/layouts/BaseLayout.tsx
+++ b/src/components/layouts/BaseLayout.tsx
@@ -21,7 +21,7 @@ const BaseLayout = ({ children }: BaseProps) => {
     ['user', payload?.username],
     () => {
       if (payload?.username === 'undefined') return router.push('/login');
-      return UserService.findUserByUsername(payload?.username as string);
+      return UserService.getFindMe();
     },
     {
       onError: (error: AxiosErrorResponseType) => {

--- a/src/components/layouts/BaseLayout.tsx
+++ b/src/components/layouts/BaseLayout.tsx
@@ -4,11 +4,12 @@ import { useRecoilState, useRecoilValue } from 'recoil';
 import { useQuery } from '@tanstack/react-query';
 import { BaseProps } from '@/core/types/common';
 import { userState } from '@/store/userAtom';
-import { AxiosErrorResponseType, UserType } from '@/core';
+import { AxiosErrorResponseType, UserType, YN } from '@/core';
 import useAuth from '@/hooks/useAuth';
 import UserService from '@/services/user';
 import { profileState } from '@/store/profileAtom';
 import BottomNav from '../nav/bottomNav/BottomNav';
+import ActivateUser from '../common/ActivateUser';
 
 const BaseLayout = ({ children }: BaseProps) => {
   const router = useRouter();
@@ -44,6 +45,17 @@ const BaseLayout = ({ children }: BaseProps) => {
   useEffect(() => {
     setUser(userInfo);
   }, [userInfo, setUser]);
+
+  // * 계정 삭제 요청 상태 시 보여주는 화면
+  if (userInfo?.delYn === YN.Y) {
+    return (
+      <main className="app-main">
+        <div className="layout__container">
+          <ActivateUser />
+        </div>
+      </main>
+    );
+  }
 
   return (
     <main className="app-main">

--- a/src/components/layouts/BaseLayout.tsx
+++ b/src/components/layouts/BaseLayout.tsx
@@ -25,9 +25,9 @@ const BaseLayout = ({ children }: BaseProps) => {
     {
       onError: (error: AxiosErrorResponseType) => {
         if (error?.response?.status === 404) {
-          alert(error?.response?.data.message);
+          // alert(error?.response?.data.message);
+          // router.push('/_error');
         }
-        router.push('/_error');
       },
     },
   );

--- a/src/components/layouts/ProfileLayout.tsx
+++ b/src/components/layouts/ProfileLayout.tsx
@@ -182,12 +182,12 @@ const ProfileLayout = ({ children }: BaseProps) => {
             ) : (
               // 1 - 미 로그인 상태
               <>
-                {profile.status === USER_STATUS.INACTIVE ? ( // 2 - 유저 활성 상태
+                {profile.status === USER_STATUS.INACTIVE ? ( // 2 - 유저 비활성 상태
                   <>
                     <InactivatedUser />
                   </>
                 ) : (
-                  // 2 - 유저 비활성 상태
+                  // 2 - 유저 활성화 상태
                   <>{children}</>
                 )}
               </>

--- a/src/components/layouts/ProfileLayout.tsx
+++ b/src/components/layouts/ProfileLayout.tsx
@@ -10,12 +10,14 @@ import { profileState } from '@/store/profileAtom';
 import { userState } from '@/store/userAtom';
 import { FollowCreateType } from '@/core/types/follow';
 import FollowService from '@/services/follow';
+import { USER_STATUS } from '@/core';
 import ProfileInfo from '../profile/ProfileInfo';
 import ProfileCount from '../profile/ProfileCount';
 import ProfileFeedTabs from '../profile/ProfileFeedTabs';
 import Button from '../common/Button';
 import TopHeader from '../nav/topHeader/TopHeader';
 import LoadingSpinner from '../common/LoadingSpinner';
+import InactivatedUser from '../common/InactivatedUser';
 
 const ProfileLayout = ({ children }: BaseProps) => {
   const router = useRouter();
@@ -34,8 +36,8 @@ const ProfileLayout = ({ children }: BaseProps) => {
       onError: (error: AxiosErrorResponseType) => {
         if (error?.response?.status === 404) {
           alert(error?.response?.data.message);
+          router.push('/_error');
         }
-        router.push('/_error');
       },
     },
   );
@@ -96,7 +98,7 @@ const ProfileLayout = ({ children }: BaseProps) => {
           <h1 className="blind">프로필</h1>
         </TopHeader.Title>
         <TopHeader.Right>
-          {profile && (
+          {payload && profile ? (
             <>
               {payload?.username === profile.username && (
                 <button onClick={() => router.push('/profile/edit')}>
@@ -104,6 +106,8 @@ const ProfileLayout = ({ children }: BaseProps) => {
                 </button>
               )}
             </>
+          ) : (
+            <button onClick={() => router.push('/login')}>로그인</button>
           )}
         </TopHeader.Right>
       </TopHeader>
@@ -123,6 +127,7 @@ const ProfileLayout = ({ children }: BaseProps) => {
               </Button>
             </div>
           )}
+
           {payload && payload?._id !== profile.id && (
             <div className="text-center">
               {myInfo?.followingIds.includes(profile?.id) ? (
@@ -153,7 +158,31 @@ const ProfileLayout = ({ children }: BaseProps) => {
           <ProfileCount profile={profile} />
           <section className="profile-feeds">
             <ProfileFeedTabs />
-            {children}
+            {payload ? ( // 1 - 로그인 상태
+              <>
+                {payload.username !== profile.username ? ( // 2 -다른 유저 프로필
+                  <>
+                    {!myInfo?.followingIds.includes(profile?.id) &&
+                    profile.status === USER_STATUS.INACTIVE ? ( // 3- 유저 비활성 상태 & 팔로잉 안했을 경우
+                      <>
+                        <InactivatedUser />
+                      </>
+                    ) : (
+                      // 3- 유저비활성 상태 & 팔로잉 했을 경우
+                      <> {children}</>
+                    )}
+                  </>
+                ) : (
+                  // 2- 내 프로필
+                  <> {children}</>
+                )}
+              </>
+            ) : (
+              // 1 - 미 로그인 상태
+              <>
+                <InactivatedUser />
+              </>
+            )}
           </section>
         </div>
       )}

--- a/src/components/layouts/ProfileLayout.tsx
+++ b/src/components/layouts/ProfileLayout.tsx
@@ -130,7 +130,8 @@ const ProfileLayout = ({ children }: BaseProps) => {
 
           {payload && payload?._id !== profile.id && (
             <div className="text-center">
-              {myInfo?.followingIds.includes(profile?.id) ? (
+              {myInfo?.followingIds &&
+              myInfo?.followingIds.includes(profile?.id) ? (
                 <>
                   <Button
                     variant="gray"
@@ -162,13 +163,14 @@ const ProfileLayout = ({ children }: BaseProps) => {
               <>
                 {payload.username !== profile.username ? ( // 2 -다른 유저 프로필
                   <>
-                    {!myInfo?.followingIds.includes(profile?.id) &&
-                    profile.status === USER_STATUS.INACTIVE ? ( // 3- 유저 비활성 상태 & 팔로잉 안했을 경우
+                    {myInfo?.followingIds &&
+                    !myInfo?.followingIds.includes(profile?.id) &&
+                    profile.status === USER_STATUS.INACTIVE ? ( // 3- 유저 비활성 상태 & 팔로잉 안 했을 경우
                       <>
                         <InactivatedUser />
                       </>
                     ) : (
-                      // 3- 유저비활성 상태 & 팔로잉 했을 경우
+                      // 3- 유저 비활성 상태 & 팔로잉 했을 경우
                       <> {children}</>
                     )}
                   </>
@@ -180,7 +182,14 @@ const ProfileLayout = ({ children }: BaseProps) => {
             ) : (
               // 1 - 미 로그인 상태
               <>
-                <InactivatedUser />
+                {profile.status === USER_STATUS.INACTIVE ? ( // 2 - 유저 활성 상태
+                  <>
+                    <InactivatedUser />
+                  </>
+                ) : (
+                  // 2 - 유저 비활성 상태
+                  <>{children}</>
+                )}
               </>
             )}
           </section>

--- a/src/components/profile/ProfileCount.tsx
+++ b/src/components/profile/ProfileCount.tsx
@@ -22,7 +22,10 @@ function ProfileCount({ profile }: ProfileCountType) {
 
   const onClickFollowUserModalOpen = (queryKey: string) => {
     if (!payload) return alert('로그인이 필요합니다');
-    if (!myInfo?.followingIds.includes(profile.id))
+    if (
+      payload.username !== profile.username &&
+      !myInfo?.followingIds.includes(profile.id)
+    )
       return alert('리스트를 보려면 팔로우하세요');
     setQueryKey(queryKey);
     setIsFollowingModalOpen(true);

--- a/src/components/profile/ProfileCount.tsx
+++ b/src/components/profile/ProfileCount.tsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
+import { useRecoilValue } from 'recoil';
 import { FOLLOW, UserType, followTransformer } from '@/core';
 import useAuth from '@/hooks/useAuth';
+import { userState } from '@/store/userAtom';
 import Modal from '../common/Modal';
 import FollowList from '../follow/FollowList';
 
@@ -14,19 +16,19 @@ function ProfileCount({ profile }: ProfileCountType) {
   const queryClient = useQueryClient();
   const router = useRouter();
   const { payload } = useAuth();
+  const myInfo = useRecoilValue(userState);
   const [queryKey, setQueryKey] = useState('');
   const [isFollowingModalOpen, setIsFollowingModalOpen] = useState(false);
 
   const onClickFollowUserModalOpen = (queryKey: string) => {
     if (!payload) return alert('로그인이 필요합니다');
-
+    if (!myInfo?.followingIds.includes(profile.id))
+      return alert('리스트를 보려면 팔로우하세요');
     setQueryKey(queryKey);
     setIsFollowingModalOpen(true);
   };
 
   const onClickFollowUserModalClose = () => {
-    if (!payload) return alert('로그인이 필요합니다');
-
     setIsFollowingModalOpen(false);
     setQueryKey('');
     return queryClient.invalidateQueries(['user', router.query.username]);

--- a/src/components/profile/ProfileCount.tsx
+++ b/src/components/profile/ProfileCount.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
 import { FOLLOW, UserType, followTransformer } from '@/core';
+import useAuth from '@/hooks/useAuth';
 import Modal from '../common/Modal';
 import FollowList from '../follow/FollowList';
 
@@ -12,15 +13,20 @@ interface ProfileCountType {
 function ProfileCount({ profile }: ProfileCountType) {
   const queryClient = useQueryClient();
   const router = useRouter();
+  const { payload } = useAuth();
   const [queryKey, setQueryKey] = useState('');
   const [isFollowingModalOpen, setIsFollowingModalOpen] = useState(false);
 
   const onClickFollowUserModalOpen = (queryKey: string) => {
+    if (!payload) return alert('로그인이 필요합니다');
+
     setQueryKey(queryKey);
     setIsFollowingModalOpen(true);
   };
 
   const onClickFollowUserModalClose = () => {
+    if (!payload) return alert('로그인이 필요합니다');
+
     setIsFollowingModalOpen(false);
     setQueryKey('');
     return queryClient.invalidateQueries(['user', router.query.username]);

--- a/src/components/settings/SettingsList.tsx
+++ b/src/components/settings/SettingsList.tsx
@@ -12,8 +12,8 @@ const SettingsList = ({ title, items }: SettingsListType) => {
     <div className={styles.list}>
       {title && <h3 className={styles.title}>{title}</h3>}
       <div className={styles.items}>
-        {items.map((item) => (
-          <SettingsListItem item={item} />
+        {items.map((item, index) => (
+          <SettingsListItem item={item} key={index} />
         ))}
       </div>
     </div>

--- a/src/core/base.service.ts
+++ b/src/core/base.service.ts
@@ -36,6 +36,8 @@ api.interceptors.response.use(
     if (error.code === 'ERR_NETWORK') {
       alert('네트워크 오류');
       location.replace('/');
+      JwtStorageService.removeToken(ACCESS_TOKEN);
+      JwtStorageService.removeToken(REFRESH_TOKEN);
     }
     if (error.response) {
       const { data } = error.response;

--- a/src/core/environments/api/user.ts
+++ b/src/core/environments/api/user.ts
@@ -2,4 +2,5 @@ export const USER_API = {
   FIND_ME: '/user/find-me',
   UPDATE_STATUS: '/user/status',
   USER: '/user',
+  ACTIVATE_USER: '/user/activate-account',
 };

--- a/src/core/environments/api/user.ts
+++ b/src/core/environments/api/user.ts
@@ -1,4 +1,5 @@
 export const USER_API = {
   FIND_ME: '/user/find-me',
+  UPDATE_STATUS: '/user/status',
   USER: '/user',
 };

--- a/src/core/types/user/index.ts
+++ b/src/core/types/user/index.ts
@@ -1,3 +1,4 @@
 export * from './user.interface';
 export * from './user-create.interface';
 export * from './user-update.interface';
+export * from './user-delete.interface';

--- a/src/core/types/user/user-delete.interface.ts
+++ b/src/core/types/user/user-delete.interface.ts
@@ -1,0 +1,3 @@
+export interface UserDeleteType {
+  password: string;
+}

--- a/src/core/types/user/user-update-status.interface.ts
+++ b/src/core/types/user/user-update-status.interface.ts
@@ -1,0 +1,5 @@
+import { USER_STATUS } from '@/core/enum';
+
+export interface UserUpdateStatusType {
+  status: USER_STATUS;
+}

--- a/src/core/types/user/user.interface.ts
+++ b/src/core/types/user/user.interface.ts
@@ -1,4 +1,4 @@
-import { GENDER, USER_STATUS } from '@/core/enum';
+import { GENDER, USER_STATUS, YN } from '@/core/enum';
 
 export interface UserType {
   id: number;
@@ -6,6 +6,8 @@ export interface UserType {
   nickname: string;
   email: string;
   status: USER_STATUS;
+  inactiveAt?: Date;
+  delYn?: YN;
   followerCount?: number;
   followingCount?: number;
   feedCount?: number;

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,5 +1,4 @@
 import jwtDecode from 'jwt-decode';
-import { useRouter } from 'next/router';
 import { useSetRecoilState } from 'recoil';
 import JwtStorageService, {
   ACCESS_TOKEN,
@@ -9,7 +8,6 @@ import { UserPayloadType } from '@/core';
 import { userState } from '@/store/userAtom';
 
 const useAuth = () => {
-  const router = useRouter();
   const accessToken = JwtStorageService.getToken(ACCESS_TOKEN);
   const resetUser = useSetRecoilState(userState);
   let decodePayload: UserPayloadType | null = null;

--- a/src/pages/feed/index.tsx
+++ b/src/pages/feed/index.tsx
@@ -2,28 +2,22 @@ import React, { useEffect } from 'react';
 import { dehydrate, QueryClient, useQuery } from '@tanstack/react-query';
 import Link from 'next/link';
 import { ImSpinner6 } from 'react-icons/im';
-import { useRecoilValue } from 'recoil';
 import { FeedType } from '@/core/types/feed';
 import FeedItem from '@/components/feed/FeedItem';
 import TopHeader from '@/components/nav/topHeader/TopHeader';
 import LogoTitleSVG from '@/assets/intro/logo_title.svg';
 import FeedService from '@/services/feed';
 import { useInfinityScroll } from '@/hooks/useInfinityScroll';
-import { userState } from '@/store/userAtom';
-import useAuth from '@/hooks/useAuth';
 import { InfinitePagesType } from '@/core/types/common';
 import { useLocalStorage } from '../../hooks/useLocalStorage';
 
 const Feed = () => {
   const [scrollY] = useLocalStorage('scroll_location', 0);
-  const user = useRecoilValue(userState);
-  const { payload } = useAuth();
 
   const { data: feeds } = useQuery<InfinitePagesType<FeedType>>(['feeds'], () =>
     FeedService.getFeeds({
       page: 1,
       limit: 10,
-      userId: user?.id || payload?._id,
     }),
   );
 

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -15,11 +15,7 @@ import IconGoogle from '@/assets/icons/icon_google.svg';
 import { userState } from '@/store/userAtom';
 
 const Login = () => {
-  const {
-    formData: authLogin,
-    onChange,
-    onReset,
-  } = useForm<AuthLoginType>({
+  const { formData: authLogin, onChange } = useForm<AuthLoginType>({
     email: '',
     password: '',
     rememberMe: true,
@@ -29,8 +25,10 @@ const Login = () => {
   const [errorMessage, setErrorMessage] = useState([]);
   const setUser = useSetRecoilState(userState);
 
-  const { mutateAsync, isError } = useMutation((formData: AuthLoginType) =>
-    AuthService.login(formData),
+  const { mutateAsync, isError, isSuccess } = useMutation(
+    (formData: AuthLoginType) => {
+      return AuthService.login(formData);
+    },
   );
 
   const onSubmitForm = async (
@@ -43,8 +41,10 @@ const Login = () => {
       if (accessToken) {
         JwtStorageService.setToken(ACCESS_TOKEN, `${accessToken}`);
         setUser(userInfo);
-        onReset();
-        router.replace('/feed');
+        router.reload();
+        if (isSuccess) {
+          router.replace('/feed');
+        }
       }
     } catch (error: any) {
       console.log('error?.response', error?.response);

--- a/src/pages/settings/account-status/index.tsx
+++ b/src/pages/settings/account-status/index.tsx
@@ -1,0 +1,140 @@
+import React, { useState } from 'react';
+import { useRouter } from 'next/router';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useRecoilValue } from 'recoil';
+import TopHeader from '@/components/nav/topHeader/TopHeader';
+import SettingsHeader from '@/components/settings/SettingsHeader';
+import { USER_STATUS } from '@/core';
+import UserService from '@/services/user';
+import Dialog from '@/components/dialog/Dialog';
+import TypoText from '@/components/common/TypoText';
+import { userState } from '@/store/userAtom';
+import SwitchButton from '@/components/common/SwitchButton';
+import LoadingSpinner from '@/components/common/LoadingSpinner';
+
+const AccountStatus = () => {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
+  const myInfo = useRecoilValue(userState);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const { mutateAsync, isLoading } = useMutation({
+    mutationFn: async () => {
+      if (myInfo?.status === USER_STATUS.ACTIVE) {
+        return await UserService.updateUserStatus({
+          status: USER_STATUS.INACTIVE,
+        });
+      } else {
+        return await UserService.updateUserStatus({
+          status: USER_STATUS.ACTIVE,
+        });
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries(['user', myInfo?.username]);
+      setIsModalOpen(false);
+    },
+  });
+
+  const onChangeUserStatusHandler = () => {
+    mutateAsync();
+  };
+
+  const onClickModalOpenHandler = () => {
+    setIsModalOpen((prevStatus) => !prevStatus);
+  };
+
+  return (
+    <>
+      <TopHeader>
+        <TopHeader.Left>
+          <button onClick={() => router.back()}>뒤로</button>
+        </TopHeader.Left>
+        <TopHeader.Title></TopHeader.Title>
+        <TopHeader.Right></TopHeader.Right>
+      </TopHeader>
+      <article className="article__container">
+        <div className="inner__container">
+          <SettingsHeader>
+            <SettingsHeader.Title>계정 공개 범위</SettingsHeader.Title>
+            <SettingsHeader.Desc>
+              계정이 공개 상태인 경우 계정이 없는 사람을 포함해서 모든 사람이
+              프로필과 게시물을 볼 수 있습니다.
+              <br />
+              <br />
+              계정이 비공개 상태인 경우 회원님이 승인한 팔로워만 회원님이
+              공유하는 콘텐츠, 팔로워 및 팔로잉 리스트를 볼 수 있습니다.
+            </SettingsHeader.Desc>
+          </SettingsHeader>
+          <SwitchButton
+            id="aa"
+            defaultChecked={
+              myInfo?.status === USER_STATUS.INACTIVE ? true : false
+            }
+            label="계정 비활성화"
+            readOnly={true}
+            onClick={onClickModalOpenHandler}
+          />
+        </div>
+      </article>
+      <Dialog isOpen={isModalOpen}>
+        <Dialog.Dimmed onClick={onClickModalOpenHandler} />
+        <Dialog.Content>
+          <div className="text-center">
+            {myInfo?.status === USER_STATUS.ACTIVE ? (
+              <>
+                <TypoText tagName="h3" color="white">
+                  <>
+                    비공개 계정으로 <br />
+                    전환하시겠습니까?
+                  </>
+                </TypoText>
+                <TypoText tagName="p" color="gray">
+                  회원님의 팔로워만 회원님의 <br />
+                  피드를 볼 수 있습니다
+                </TypoText>
+              </>
+            ) : (
+              <>
+                <TypoText tagName="h3" color="white">
+                  <>
+                    공개 계정으로 <br />
+                    전환하시겠습니까?
+                  </>
+                </TypoText>
+                <TypoText tagName="p" color="gray">
+                  누구나 회원님의 피드를 <br />볼 수 있습니다
+                </TypoText>
+              </>
+            )}
+          </div>
+        </Dialog.Content>
+        <Dialog.LabelButton
+          color="essential"
+          onClick={() => onChangeUserStatusHandler()}
+        >
+          {isLoading ? (
+            <>
+              <LoadingSpinner variant="white" />
+            </>
+          ) : (
+            <>
+              {myInfo?.status === USER_STATUS.ACTIVE
+                ? '비공개로 전환'
+                : '공개로 전환'}
+            </>
+          )}
+        </Dialog.LabelButton>
+        <Dialog.LabelButton
+          color="white"
+          onClick={() => onClickModalOpenHandler()}
+        >
+          취소
+        </Dialog.LabelButton>
+      </Dialog>
+    </>
+  );
+};
+
+export default AccountStatus;

--- a/src/pages/settings/delete-account/index.tsx
+++ b/src/pages/settings/delete-account/index.tsx
@@ -1,0 +1,130 @@
+import React, { FormEvent, useState } from 'react';
+import { useRouter } from 'next/router';
+import { useMutation } from '@tanstack/react-query';
+import TopHeader from '@/components/nav/topHeader/TopHeader';
+import SettingsHeader from '@/components/settings/SettingsHeader';
+import useForm from '@/hooks/useForm';
+import ErrorMessage from '@/components/common/ErrorMessage';
+import ButtonGroup from '@/components/common/ButtonGroup';
+import Button from '@/components/common/Button';
+import UserService from '@/services/user';
+import { AxiosErrorResponseType, UserDeleteType } from '@/core';
+import Dialog from '@/components/dialog/Dialog';
+import LoadingSpinner from '@/components/common/LoadingSpinner';
+import TypoText from '@/components/common/TypoText';
+import useAuth from '@/hooks/useAuth';
+
+const DeleteAccount = () => {
+  const router = useRouter();
+  const { onLogout } = useAuth();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [errorMessage, setErrorMessage] = useState([]);
+
+  const { mutateAsync, isLoading, isError } = useMutation({
+    mutationFn: (formData: UserDeleteType) => UserService.deleteUser(formData),
+    onSuccess: () => {
+      setIsModalOpen(false);
+      onLogout();
+    },
+    onError: (error: AxiosErrorResponseType) => {
+      setErrorMessage(error?.response?.data.message);
+    },
+  });
+
+  const { formData: accountDelete, onChange } = useForm<UserDeleteType>({
+    password: '',
+  });
+
+  const onClickDeleteUserHandler = (formData: UserDeleteType) => {
+    mutateAsync(formData);
+  };
+
+  const onClickModalOpenHandler = (event?: FormEvent) => {
+    event?.preventDefault();
+    setIsModalOpen((prevStatus) => !prevStatus);
+  };
+
+  return (
+    <>
+      <TopHeader>
+        <TopHeader.Left>
+          <button onClick={() => router.back()}>뒤로</button>
+        </TopHeader.Left>
+        <TopHeader.Title>계정 삭제</TopHeader.Title>
+        <TopHeader.Right></TopHeader.Right>
+      </TopHeader>
+      <article className="article__container">
+        <div className="inner__container">
+          <SettingsHeader>
+            <SettingsHeader.Title>계정 삭제</SettingsHeader.Title>
+            <SettingsHeader.Desc>
+              회원을 탈퇴할 경우, 계정 상태가 비활성화 되며 <br />
+              7일 이후에는 계정이 영구 삭제되고, 로그인이
+              <br /> 불가능하게 됩니다 <br />
+              <br />
+              탈퇴 철회를 원하시면 7일 이내에 재 로그인하면 <br />
+              계정 상태가 활성화 됩니다
+            </SettingsHeader.Desc>
+          </SettingsHeader>
+          <form className="form" onSubmit={onClickModalOpenHandler}>
+            <div className="form-group">
+              <div className="input-group">
+                <div className="input-field">
+                  <input
+                    type="password"
+                    name="password"
+                    value={accountDelete.password}
+                    placeholder="현재 비밀번호"
+                    onChange={onChange}
+                  />
+                </div>
+              </div>
+            </div>
+            {isError && <ErrorMessage errorMessage={errorMessage} />}
+            <ButtonGroup>
+              <Button
+                size="md"
+                variant="primary"
+                type="submit"
+                isEnglish
+                isFull
+              >
+                OK
+              </Button>
+            </ButtonGroup>
+          </form>
+        </div>
+      </article>
+      <Dialog isOpen={isModalOpen}>
+        <Dialog.Dimmed onClick={onClickModalOpenHandler} />
+        <Dialog.Content>
+          <div className="text-center">
+            <TypoText tagName="p" color="white">
+              계정을 삭제할까요?
+            </TypoText>
+          </div>
+        </Dialog.Content>
+        <Dialog.LabelButton
+          color="danger"
+          onClick={() => onClickDeleteUserHandler(accountDelete)}
+        >
+          {isLoading ? (
+            <>
+              <LoadingSpinner variant="white" />
+            </>
+          ) : (
+            <>삭제하기</>
+          )}
+        </Dialog.LabelButton>
+        <Dialog.LabelButton
+          color="white"
+          onClick={() => onClickModalOpenHandler()}
+        >
+          취소
+        </Dialog.LabelButton>
+      </Dialog>
+    </>
+  );
+};
+
+export default DeleteAccount;

--- a/src/pages/settings/delete-account/index.tsx
+++ b/src/pages/settings/delete-account/index.tsx
@@ -22,21 +22,22 @@ const DeleteAccount = () => {
 
   const { mutateAsync, isLoading, isError } = useMutation({
     mutationFn: (formData: UserDeleteType) => UserService.deleteUser(formData),
-    onSuccess: () => {
-      setIsModalOpen(false);
-      onLogout();
-    },
-    onError: (error: AxiosErrorResponseType) => {
-      setErrorMessage(error?.response?.data.message);
-    },
   });
 
   const { formData: accountDelete, onChange } = useForm<UserDeleteType>({
     password: '',
   });
 
-  const onClickDeleteUserHandler = (formData: UserDeleteType) => {
-    mutateAsync(formData);
+  const onClickDeleteUserHandler = async (formData: UserDeleteType) => {
+    try {
+      await mutateAsync(formData);
+      setIsModalOpen(false);
+      onLogout();
+    } catch (error: any) {
+      console.log('error?.response', error?.response);
+      setErrorMessage(error?.response?.data.message);
+      setIsModalOpen(false);
+    }
   };
 
   const onClickModalOpenHandler = (event?: FormEvent) => {
@@ -100,6 +101,7 @@ const DeleteAccount = () => {
         <Dialog.Content>
           <div className="text-center">
             <TypoText tagName="p" color="white">
+              정말로 <br />
               계정을 삭제할까요?
             </TypoText>
           </div>

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useRouter } from 'next/router';
 import { RiLockPasswordLine, RiFileUserLine } from 'react-icons/ri';
 import { MdSecurity, MdNoAccounts } from 'react-icons/md';
-import { BiHelpCircle } from 'react-icons/bi';
+import { BiHelpCircle, BiTrash } from 'react-icons/bi';
 import TopHeader from '@/components/nav/topHeader/TopHeader';
 import SettingsList, {
   SettingsListType,
@@ -48,6 +48,11 @@ const Settings = () => {
         {
           icon: <BiHelpCircle />,
           title: '도움말',
+        },
+        {
+          icon: <BiTrash />,
+          title: '계정 삭제',
+          onClick: () => router.push('/settings/delete-account'),
         },
       ],
     },

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useRouter } from 'next/router';
 import { RiLockPasswordLine, RiFileUserLine } from 'react-icons/ri';
 import { MdSecurity, MdNoAccounts } from 'react-icons/md';
-import { BiHelpCircle, BiLike, BiBlock } from 'react-icons/bi';
+import { BiHelpCircle } from 'react-icons/bi';
 import TopHeader from '@/components/nav/topHeader/TopHeader';
 import SettingsList, {
   SettingsListType,
@@ -27,22 +27,19 @@ const Settings = () => {
           icon: <RiFileUserLine />,
           title: '개인정보',
         },
-        {
-          icon: <MdSecurity />,
-          title: '내 정보 및 권한',
-        },
       ],
     },
     {
       title: '콘텐츠 정보',
       items: [
         {
-          icon: <BiLike />,
-          title: '좋아요 수 노출 관리',
+          icon: <MdSecurity />,
+          title: '계정 공개 범위',
+          onClick: () => router.push('/settings/account-status'),
         },
         {
           icon: <MdNoAccounts />,
-          title: '차단 유저 관리',
+          title: '차단된 계정',
         },
       ],
     },
@@ -51,10 +48,6 @@ const Settings = () => {
         {
           icon: <BiHelpCircle />,
           title: '도움말',
-        },
-        {
-          icon: <BiBlock />,
-          title: '계정 삭제',
         },
       ],
     },

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -71,8 +71,8 @@ const Settings = () => {
       </TopHeader>
       <article className="article__container">
         <div className="inner__container">
-          {settingList.map((list) => (
-            <SettingsList title={list.title} items={list.items} />
+          {settingList.map((list, index) => (
+            <SettingsList title={list.title} items={list.items} key={index} />
           ))}
           <div className="button-group">
             <Button

--- a/src/services/user/index.ts
+++ b/src/services/user/index.ts
@@ -1,5 +1,6 @@
 import { USER_API, UserCreateType, UserUpdateType } from '@/core';
 import { api } from '@/core/base.service';
+import { UserDeleteType } from '@/core/types/user/user-delete.interface';
 import { UserUpdateStatusType } from '@/core/types/user/user-update-status.interface';
 
 const UserService = {
@@ -21,6 +22,16 @@ const UserService = {
   },
   updateUserStatus: async (formData: UserUpdateStatusType) => {
     const { data } = await api.patch(USER_API.UPDATE_STATUS, formData);
+    return data.data;
+  },
+  deleteUser: async (formData: UserDeleteType) => {
+    const { data } = await api.delete(USER_API.USER, {
+      data: formData,
+    });
+    return data.data;
+  },
+  activateUser: async () => {
+    const { data } = await api.patch(USER_API.ACTIVATE_USER);
     return data.data;
   },
   findAllUserData: async () => {

--- a/src/services/user/index.ts
+++ b/src/services/user/index.ts
@@ -1,5 +1,6 @@
 import { USER_API, UserCreateType, UserUpdateType } from '@/core';
 import { api } from '@/core/base.service';
+import { UserUpdateStatusType } from '@/core/types/user/user-update-status.interface';
 
 const UserService = {
   getFindMe: async () => {
@@ -16,6 +17,10 @@ const UserService = {
   },
   updateUser: async (id: number, formData: UserUpdateType) => {
     const { data } = await api.patch(`/user/${id}`, formData);
+    return data.data;
+  },
+  updateUserStatus: async (formData: UserUpdateStatusType) => {
+    const { data } = await api.patch(USER_API.UPDATE_STATUS, formData);
     return data.data;
   },
   findAllUserData: async () => {

--- a/src/styles/components/common/_button.scss
+++ b/src/styles/components/common/_button.scss
@@ -116,7 +116,7 @@ $size-lg: 4rem;
 
   // full size
   &-size--full {
-    width: 100%;
+    width: 100%; 
   }
 
   // english
@@ -144,5 +144,11 @@ $size-lg: 4rem;
   svg {
     width: 1.5em;
     height: 1.5em;
+  }
+}
+
+.button-size--full {
+  + .button-size--full {
+    margin-top: 1rem;
   }
 }

--- a/src/styles/components/common/_button.scss
+++ b/src/styles/components/common/_button.scss
@@ -31,11 +31,11 @@ $size-lg: 4rem;
     color: var(--black);
   }
   &-bg--primary {
-    background: var(--button-primary-color);
+    background: var(--primary-bg-color);
     color: var(--white);
   }
   &-bg--secondary {
-    background: var(--button-secondary-color);
+    background: var(--secondary-color);
     color: var(--white);
   }
   &-bg--essential {

--- a/src/styles/components/profile/_profile-info.scss
+++ b/src/styles/components/profile/_profile-info.scss
@@ -51,7 +51,7 @@
     &__image {
       position: relative;
       z-index: 1;
-      background: var(--button-primary-color);
+      background: var(--primary-bg-color);
       margin: 0 auto;
       width: 7.5rem;
       height: 7.5rem;

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -11,7 +11,7 @@
   }
   &::-webkit-scrollbar-thumb {
     border-radius: 2rem;
-    background-color: var(--button-secondary-color);
+    background-color: var(--secondary-color);
     background-clip: padding-box;
     border: 2px solid transparent;
   }
@@ -37,18 +37,21 @@ a {
 :root {
   --border-color: #35395b;
   --bg-color: #1f2349;
-  --danger-color: #ff004d;
-  --success-color: #2f9381;
-  --white: #fff;
-  --black: #000;
-  --gray: #727272;
-  --essential-color: #1ba2f3;
-  --button-secondary-color: #5356a5;
-  --button-primary-color: linear-gradient(
+  --primary-bg-color: linear-gradient(
     270deg,
     #5322e0 3.82%,
     #5fafd4 105.73%
   );
+  --primary-color: #5322e0;
+  --secondary-color: #5356a5;
+  --danger-color: #ff004d;
+  --warning-color: #e8b703;
+  --success-color: #00e1b9;
+  --essential-color: #1ba2f3;
+  --white: #ffffff;
+  --black: #262626;
+  --gray: #727272;
+
 
   --border-radius-md: 0.5rem; /* 8px */
   --border-radius-lg: 1rem; /* 16px */
@@ -87,6 +90,7 @@ a {
     overflow-y: auto;
   }
 }
+
 
 // import compnents
 @import './components/index';


### PR DESCRIPTION
## 🐳 개요
계정 활성/비활성화 및 계정 삭제 기능  

## 🐳 작업사항
- 계정 활성/비활성화 

| 비활성화| 활성화 |  |
| --- | --- | --- |
| ![image](https://github.com/PlaNet-Devteam/sns-project-client/assets/52031484/d7b7dc78-145e-47e3-b78d-cbff24677031) | ![image](https://github.com/PlaNet-Devteam/sns-project-client/assets/52031484/0a645d17-48e3-4fd9-9601-16013962ddf8) | ![google_screen_recording_2023-10-31T12-10_20 977Z](https://github.com/PlaNet-Devteam/sns-project-client/assets/52031484/e14206f4-b500-4bb6-9a6b-d704466e8b80) |

- 계정 공개 여부
  - case1 :  활성화 된 계정 -> 비회원을 포함한 모든 유저가 프로필 및 피드 열람 가능 
  - case2  : 비활성화 된 계정 -> 로그인 및 팔로잉 여부에 따라 프로필 및 피드 열람 가능 
 
| 미 로그인 상태 | 로그인 - 언팔로우 상태  | 로그인 - 팔로우 상태 |
| --- | --- | --- |
| ![image](https://github.com/PlaNet-Devteam/sns-project-client/assets/52031484/dc9ed6e4-f39d-4fd4-86ca-96f142987a0e) | ![image](https://github.com/PlaNet-Devteam/sns-project-client/assets/52031484/ac71837d-0d2e-4051-afe0-5c232fefd9c8) | ![image](https://github.com/PlaNet-Devteam/sns-project-client/assets/52031484/bb4dbb09-5376-43a0-9753-c2d9dd6e2208) |
| - 피드 목록 확인 불가 <br/>- 팔로워&팔로잉 목록 확인 불가 <br/>- 상단 로그인 버튼 노출   | - 피드 목록 확인 불가 <br/>- 팔로워&팔로잉 목록 확인 불가 <br />- 팔로우 버튼 노출  | - 피드 목록 확인 가능 <br/>- 팔로워&팔로잉 목록 확인 가능<br />- 팔로우 취소 버튼 노출  |

- 계정 삭제 및 복구 
  - 유저 상태 `delYn` 프로퍼티로 상태 여부 변경

| 계정 삭제 실패 <br/>- 비밀번호 오류 | 계정 삭제 성공 |  계정 삭제 취소  | 
| --- | --- | --- |
| ![google_screen_recording_2023-10-31T15-20_03 438Z](https://github.com/PlaNet-Devteam/sns-project-client/assets/52031484/d6a3e63f-c134-40fe-96ff-b1a018ed3f7a) | ![google_screen_recording_2023-10-31T15-20_29 371Z](https://github.com/PlaNet-Devteam/sns-project-client/assets/52031484/520d2ec7-76b8-4fcd-a277-b8ecdf2bde09) | ![google_screen_recording_2023-10-31T15-23_01 340Z](https://github.com/PlaNet-Devteam/sns-project-client/assets/52031484/3d740b43-1f69-4304-b8f1-a665513e8735) |
  
- 피드 목록 -> 팔로잉한 유저 및 내가 작성한 피드 목록 노출 (서버 로직 수정)
 

## 🐳 공유사항
#### 계정 활성/비활성화
- 계정 비활성화 시 팔로워/팔로잉 목록 조회에서 제거되지 않음 -> 해당 유저의 프로필 페이지 및 피드가 공개 여부만 처리
- 비활성화된 계정에게 팔로잉 요청할 경우 원래는 승인 하는 단계를 거쳐야 하나(맞팔로잉 개념) ,현재 복잡한 로직을 우선 제외하고 개발함
#### 계정 삭제
- 계정 삭제 시 팔로워/팔로잉 목록 조회에서 해당 유저가 제외됨  -> 추후 팔로잉, 팔로워 count 를 증가/감소 시키는 로직 추가 필요 
- 계정 삭제시 `delYn` 값이 `Y` 값으로 변경되며, 요청한 날짜(inactiveAt) 를 기준으로 7일 후에 영구 삭제할 예정 (추후 개발)
   - 해당 계정과 관련된 피드, 댓글 데이터 등을 영구 삭제해야될지 남겨줘야 될지 등의 탈퇴 정책 방침에 대한 고민이 필요할듯하여, 추후 로직이 변경될 가능성 있음 


