### PR TITLE
refactor: 로그아웃 API 요청 기능 추가 #89

### DIFF
--- a/src/core/environments/api/auth.ts
+++ b/src/core/environments/api/auth.ts
@@ -1,5 +1,6 @@
 export const AUTH_API = {
   LOGIN: '/auth/login',
+  LOGOUT: '/auth/logout',
   REFRESH_TOKEN: '/auth/refresh-token',
   CHANGE_PASSWORD: '/auth/change-password',
 };

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -6,6 +6,7 @@ import JwtStorageService, {
 } from '@/core/utils/jwt-storage';
 import { UserPayloadType } from '@/core';
 import { userState } from '@/store/userAtom';
+import AuthService from '@/services/auth';
 
 const useAuth = () => {
   const accessToken = JwtStorageService.getToken(ACCESS_TOKEN);
@@ -16,11 +17,14 @@ const useAuth = () => {
     decodePayload = jwtDecode(accessToken);
   }
 
-  const onLogout = () => {
-    JwtStorageService.removeToken(ACCESS_TOKEN);
-    JwtStorageService.removeToken(REFRESH_TOKEN);
-    resetUser(null);
-    location.replace('/login');
+  const onLogout = async () => {
+    const isLoggedOut = await AuthService.logout();
+    if (isLoggedOut) {
+      JwtStorageService.removeToken(ACCESS_TOKEN);
+      JwtStorageService.removeToken(REFRESH_TOKEN);
+      resetUser(null);
+      location.replace('/login');
+    }
   };
 
   return {

--- a/src/services/auth/index.ts
+++ b/src/services/auth/index.ts
@@ -6,6 +6,10 @@ const AuthService = {
     const { data } = await api.post(AUTH_API.LOGIN, formData);
     return data.data;
   },
+  logout: async () => {
+    const { data } = await api.post(AUTH_API.LOGOUT);
+    return data.data;
+  },
   refreshToken: async () => {
     const { data } = await api.post(AUTH_API.REFRESH_TOKEN);
     return data;


### PR DESCRIPTION
## 🐳 개요
로그아웃 API 요청 기능 추가 
close #89

## 🐳 작업사항
- 기존 로그아웃은 api 요청 없이 token 정보에 대한 로직만 있었음
-  로그인/로그아웃시 user login history 테이블에 기록을 남기기 위해 logout api 요청 기능 추가 (기존에는 로그인만 요청)
-  서버에서 device id 값도 저장하도록 수정  


