### PR TITLE
refactor: 프로필 수정 페이지 및 관련 컴포넌트 리팩토링

### DIFF
--- a/src/components/archived/ArchivedFeedList.tsx
+++ b/src/components/archived/ArchivedFeedList.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FEED_STATUS, FeedType } from '@/core';
+import { FEED_STATUS } from '@/core';
 import FeedService from '@/services/feed';
 import useAuth from '@/hooks/useAuth';
 import InfinityDataList from '../common/InfinityDataList';
@@ -10,7 +10,7 @@ const ArchivedFeedList = () => {
 
   return (
     <div className="profile-feeds-list">
-      <InfinityDataList<FeedType>
+      <InfinityDataList
         queryKey={['archived-feeds']}
         listType={'scroll'}
         fetchData={(page) =>
@@ -20,8 +20,7 @@ const ArchivedFeedList = () => {
             status: FEED_STATUS.ARCHIVED,
           })
         }
-        ChildCompoentToRender={ProfileFeedListItem}
-        propsObject={{ queryKey: ['archived-feeds'] }}
+        renderToChildComponent={ProfileFeedListItem}
       ></InfinityDataList>
     </div>
   );

--- a/src/components/comment/CommentReplyList.tsx
+++ b/src/components/comment/CommentReplyList.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import CommentReplyService from '@/services/comment-reply';
-import { CommentReplyType } from '@/core/types/comment-reply';
 import { ORDER_BY } from '@/core';
 import InfinityDataList from '../common/InfinityDataList';
 import CommentReplyItem from './CommentReplyItem';
@@ -12,7 +11,7 @@ interface CommentReplyListProps {
 const CommentReplyList = ({ commentId }: CommentReplyListProps) => {
   return (
     <>
-      <InfinityDataList<CommentReplyType>
+      <InfinityDataList
         queryKey={['replies', commentId]}
         listType={'button'}
         fetchData={(page) =>
@@ -22,7 +21,7 @@ const CommentReplyList = ({ commentId }: CommentReplyListProps) => {
             orderBy: ORDER_BY.ASC,
           })
         }
-        ChildCompoentToRender={CommentReplyItem}
+        renderToChildComponent={CommentReplyItem}
       ></InfinityDataList>
     </>
   );

--- a/src/components/common/InfinityDataList.tsx
+++ b/src/components/common/InfinityDataList.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ComponentType } from 'react';
 import { BaseProps, InfinitePagesType } from '@/core';
 import { useInfinityScroll } from '@/hooks/useInfinityScroll';
 import EmptyData from './EmptyData';
@@ -7,21 +7,25 @@ import Button from './Button';
 import ButtonGroup from './ButtonGroup';
 import LoadingSpinnerContainer from './LoadingSpinnerContainer';
 
+interface ChildComponentProps<T> {
+  key: number;
+  item: T;
+  queryKey: unknown[];
+}
+
 interface InfinityDataListProps<T> extends BaseProps {
   queryKey: unknown[];
   listType: 'button' | 'scroll';
-  ChildCompoentToRender: React.ComponentType<T>;
-  propsObject?: Record<string, unknown>;
+  renderToChildComponent: ComponentType<ChildComponentProps<T>>;
   fetchData: (page: number, limit?: number) => Promise<InfinitePagesType<T>>;
 }
 
 const InfinityDataList = <T,>({
   queryKey,
   listType,
-  ChildCompoentToRender,
-  propsObject,
+  renderToChildComponent,
   fetchData,
-}: InfinityDataListProps<any>) => {
+}: InfinityDataListProps<T>) => {
   const {
     data: items,
     status,
@@ -29,6 +33,8 @@ const InfinityDataList = <T,>({
     fetchNextPage,
     hasNextPage,
   } = useInfinityScroll<T>([...queryKey], fetchData);
+
+  const ChildComponent = renderToChildComponent;
 
   if (items?.pages[0].totalCount === 0) {
     return (
@@ -45,11 +51,7 @@ const InfinityDataList = <T,>({
           {items?.pages.map((page, index) => (
             <div key={index}>
               {page.items.map((item, index2) => (
-                <ChildCompoentToRender
-                  key={index2}
-                  item={item}
-                  {...propsObject}
-                />
+                <ChildComponent queryKey={queryKey} key={index2} item={item} />
               ))}
             </div>
           ))}

--- a/src/components/common/form/InputField.tsx
+++ b/src/components/common/form/InputField.tsx
@@ -49,7 +49,7 @@ const InputField = ({
           autoComplete={autoComplete}
         />
         <div className={styles.button_area}>
-          {value.length > 0 && (
+          {value && value.length > 0 && (
             <>
               {type === 'password' && (
                 <span

--- a/src/components/common/form/TextAreaField.tsx
+++ b/src/components/common/form/TextAreaField.tsx
@@ -9,6 +9,7 @@ interface TextAreaFieldProps {
   onReset: (name: string) => void;
   onChange: ChangeEventHandler<HTMLTextAreaElement>;
   placeholder?: string;
+  maxLength?: number;
 }
 
 const TextAreaField = ({
@@ -17,6 +18,7 @@ const TextAreaField = ({
   onChange,
   onReset,
   placeholder,
+  maxLength = 2000,
 }: TextAreaFieldProps) => {
   return (
     <>
@@ -26,12 +28,12 @@ const TextAreaField = ({
           onChange={onChange}
           placeholder={placeholder}
           name={name}
-          maxLength={2000}
+          maxLength={maxLength}
         />
       </div>
       <div className={styles.button_container}>
         <div>
-          {value.length > 0 && (
+          {value && value.length > 0 && (
             <button onClick={() => onReset(name)}>
               <TypoText color="white">
                 초기화 <MdOutlineRefresh />
@@ -41,9 +43,9 @@ const TextAreaField = ({
         </div>
         <TypoText color="gray" tagName="span">
           <TypoText color="white" tagName="span">
-            {value.length}
+            {value.length || 0}
           </TypoText>{' '}
-          / {2000}
+          / {maxLength}
         </TypoText>
       </div>
     </>

--- a/src/components/explore/ExploreFeedList.tsx
+++ b/src/components/explore/ExploreFeedList.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { FeedType, TagType } from '@/core';
 import FeedService from '@/services/feed';
 import useSearchInput from '@/hooks/useSearchInput';
 import TagService from '@/services/tag';
@@ -24,7 +23,7 @@ const ExploreFeedList = () => {
       />
       <div className="row-box">
         {debouncedSearchKeyword.length > 0 ? (
-          <InfinityDataList<TagType>
+          <InfinityDataList
             queryKey={['tags', debouncedSearchKeyword]}
             listType={'scroll'}
             fetchData={(page, limit) => {
@@ -34,11 +33,11 @@ const ExploreFeedList = () => {
                 query: debouncedSearchKeyword,
               });
             }}
-            ChildCompoentToRender={TagListItem}
+            renderToChildComponent={TagListItem}
           ></InfinityDataList>
         ) : (
           <div className="profile-feeds-list">
-            <InfinityDataList<FeedType>
+            <InfinityDataList
               queryKey={['allFeeds']}
               listType={'scroll'}
               fetchData={(page) =>
@@ -48,8 +47,7 @@ const ExploreFeedList = () => {
                   viewerId: payload?._id,
                 })
               }
-              ChildCompoentToRender={ProfileFeedListItem}
-              propsObject={{ queryKey: ['allFeeds'] }}
+              renderToChildComponent={ProfileFeedListItem}
             ></InfinityDataList>
           </div>
         )}

--- a/src/components/explore/ExploreUserList.tsx
+++ b/src/components/explore/ExploreUserList.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
-import { UserType } from 'aws-sdk/clients/workdocs';
-import { useRecoilValue } from 'recoil';
 import UserService from '@/services/user';
 import useSearchInput from '@/hooks/useSearchInput';
 import useAuth from '@/hooks/useAuth';
-import { userState } from '@/store/userAtom';
 import InfinityDataList from '../common/InfinityDataList';
 import SearchInput from '../common/SearchInput';
 import UserListItem from './ExploreUserListItem';
@@ -13,7 +10,6 @@ const ExploreUserList = () => {
   const { searchKeyword, onChange, onReset, debouncedSearchKeyword } =
     useSearchInput();
   const { payload } = useAuth();
-  const myInfo = useRecoilValue(userState);
 
   return (
     <>
@@ -23,7 +19,7 @@ const ExploreUserList = () => {
         onReset={onReset}
         placeholder="유저명 혹은 닉네임 검색"
       />
-      <InfinityDataList<UserType>
+      <InfinityDataList
         queryKey={['exploreUsers', debouncedSearchKeyword]}
         listType={'scroll'}
         fetchData={(page, limit) =>
@@ -34,7 +30,7 @@ const ExploreUserList = () => {
             viewerId: payload?._id,
           })
         }
-        ChildCompoentToRender={UserListItem}
+        renderToChildComponent={UserListItem}
       ></InfinityDataList>
     </>
   );

--- a/src/components/follow/FollowList.tsx
+++ b/src/components/follow/FollowList.tsx
@@ -24,7 +24,7 @@ const FollowList = ({ queryKey }: FollowListProps) => {
         onReset={onReset}
         placeholder="유저명 혹은 닉네임 검색"
       />
-      <InfinityDataList<UserType>
+      <InfinityDataList
         queryKey={[queryKey, router.query.username, debouncedSearchKeyword]}
         listType={'scroll'}
         fetchData={(page, limit) =>
@@ -35,8 +35,7 @@ const FollowList = ({ queryKey }: FollowListProps) => {
             query: debouncedSearchKeyword,
           })
         }
-        ChildCompoentToRender={FollowListItem}
-        propsObject={{ queryKey }}
+        renderToChildComponent={FollowListItem}
       ></InfinityDataList>
     </>
   );

--- a/src/components/follow/FollowListItem.tsx
+++ b/src/components/follow/FollowListItem.tsx
@@ -16,7 +16,7 @@ import LoadingSpinner from '../common/LoadingSpinner';
 import styles from './FollowListItem.module.scss';
 
 interface FollowListItemProps {
-  queryKey: string;
+  queryKey: unknown[];
   item: UserType;
 }
 
@@ -58,7 +58,7 @@ const FollowListItem = ({ queryKey, item }: FollowListItemProps) => {
       mutationFn: (formData: FollowCreateType) =>
         FollowService.deleteFollow(formData),
       onSuccess: () => {
-        queryClient.invalidateQueries([queryKey, router.query.username]);
+        queryClient.invalidateQueries([queryKey[0], router.query.username]);
         queryClient.invalidateQueries(['user', myInfo?.username]);
         setIsModalOpen(false);
       },
@@ -114,7 +114,7 @@ const FollowListItem = ({ queryKey, item }: FollowListItemProps) => {
         {myInfo?.id !== item.id && (
           <>
             <div className={styles.item_options}>
-              {queryKey === FOLLOW.FOLLOWINGS ? (
+              {queryKey[0] === FOLLOW.FOLLOWINGS ? (
                 <>
                   {followings && !followings.includes(item.id) ? (
                     <>

--- a/src/components/layouts/BaseLayout.tsx
+++ b/src/components/layouts/BaseLayout.tsx
@@ -57,6 +57,10 @@ const BaseLayout = ({ children }: BaseProps) => {
     setUser(userInfo);
   }, [userInfo, setUser]);
 
+  useEffect(() => {
+    setIsFeedModalOpen(false);
+  }, [router.asPath, setIsFeedModalOpen]);
+
   // * 계정 삭제 요청 상태 시 보여주는 화면
   if (userInfo?.delYn === YN.Y) {
     return (

--- a/src/components/profile/ProfileEditForm.tsx
+++ b/src/components/profile/ProfileEditForm.tsx
@@ -1,0 +1,143 @@
+import React, { FormEvent, useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { useRouter } from 'next/router';
+import dynamic from 'next/dynamic';
+import {
+  AxiosErrorResponseType,
+  CONST_GENDER,
+  GENDER,
+  UserType,
+  UserUpdateType,
+  genderTransformer,
+} from '@/core';
+import UserService from '@/services/user';
+import useForm from '@/hooks/useForm';
+import InputField from '../common/form/InputField';
+import TextAreaField from '../common/form/TextAreaField';
+import ButtonGroup from '../common/ButtonGroup';
+import ErrorMessage from '../common/ErrorMessage';
+import Button from '../common/Button';
+import ProfileImage from './ProfileImage';
+
+const genderOptions: GENDER[] = [...CONST_GENDER];
+
+interface ProfileEditFormProps {
+  profile: UserType;
+}
+
+const LoadingLayer = dynamic(() => import('@/components/common/LoadingLayer'), {
+  ssr: false,
+});
+
+const ProfileEditForm = ({ profile }: ProfileEditFormProps) => {
+  const router = useRouter();
+  const [errorMessage, setErrorMessage] = useState([]);
+
+  const userInitialState = {
+    nickname: profile.nickname,
+    bio: profile.bio,
+    gender: profile.gender,
+  };
+
+  const {
+    formData: userUpdate,
+    onChange,
+    onReset,
+  } = useForm<UserUpdateType>(userInitialState);
+
+  const { mutateAsync, isLoading, isError } = useMutation(
+    (formData: UserUpdateType) => {
+      if (profile.id !== undefined) {
+        return UserService.updateUser(profile.id, formData);
+      }
+      return Promise.reject(new Error('유저 정보를 불러오지 못했습니다'));
+    },
+    {
+      onSuccess: () => {
+        router.back();
+      },
+      onError: (error: AxiosErrorResponseType) => {
+        setErrorMessage(error?.response?.data.message);
+      },
+    },
+  );
+
+  const onSubmitForm = async (
+    event: FormEvent<HTMLFormElement>,
+    formData: UserUpdateType,
+  ) => {
+    event.preventDefault();
+    await mutateAsync(formData);
+  };
+
+  if (isLoading) return <LoadingLayer />;
+
+  return (
+    <div>
+      <div className="profile-info">
+        <h2 className="profile-info__title">{profile.username}</h2>
+        <ProfileImage profile={profile} />
+      </div>
+      <div className="form-area">
+        <form
+          className="login-form"
+          onSubmit={(event) => onSubmitForm(event, userUpdate)}
+        >
+          <div className="form-group">
+            <div className="input-group">
+              <InputField
+                type="text"
+                value={userUpdate.nickname || ''}
+                name="nickname"
+                placeholder="닉네임"
+                onChange={onChange}
+                onReset={onReset}
+              />
+            </div>
+            <div className="input-group">
+              <select
+                name="gender"
+                value={userUpdate.gender}
+                onChange={onChange}
+                className="select-box"
+              >
+                {genderOptions.map((option) => (
+                  <option key={option} value={option} className="select-option">
+                    {genderTransformer(option)}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="input-group">
+              <TextAreaField
+                name="bio"
+                value={userUpdate.bio || ''}
+                onReset={onReset}
+                onChange={onChange}
+                placeholder="내용을 입력해주세요."
+                maxLength={50}
+              />
+            </div>
+          </div>
+          {isError && <ErrorMessage errorMessage={errorMessage} />}
+          <ButtonGroup>
+            <Button
+              size="md"
+              variant="primary"
+              type="submit"
+              isEnglish
+              isFull
+              isDisabled={
+                JSON.stringify(userUpdate) === JSON.stringify(userInitialState)
+              }
+            >
+              EDIT
+            </Button>
+          </ButtonGroup>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default ProfileEditForm;

--- a/src/components/profile/ProfileFeedList.tsx
+++ b/src/components/profile/ProfileFeedList.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useRouter } from 'next/router';
-import { FeedType } from '@/core/types/feed';
 import FeedService from '@/services/feed';
 import useAuth from '@/hooks/useAuth';
 import InfinityDataList from '../common/InfinityDataList';
@@ -18,7 +17,7 @@ function ProfileFeedList({ queryKey }: ProfileFeedListProps) {
   return (
     <>
       <div className="profile-feeds-list">
-        <InfinityDataList<FeedType>
+        <InfinityDataList
           queryKey={[`${queryKey}-${username}`]}
           listType={'scroll'}
           fetchData={(page) => {
@@ -35,8 +34,7 @@ function ProfileFeedList({ queryKey }: ProfileFeedListProps) {
               });
             }
           }}
-          ChildCompoentToRender={ProfileFeedListItem}
-          propsObject={{ queryKey: [`${queryKey}-${username}`] }}
+          renderToChildComponent={ProfileFeedListItem}
         ></InfinityDataList>
       </div>
     </>

--- a/src/components/profile/ProfileFeedListItem.tsx
+++ b/src/components/profile/ProfileFeedListItem.tsx
@@ -11,7 +11,7 @@ import { FeedType } from '@/core/types/feed';
 import styles from './ProfileFeedListItem.module.scss';
 
 interface ProfileFeedListItemProps {
-  queryKey: string[];
+  queryKey: unknown[];
   item: FeedType;
 }
 

--- a/src/components/profile/ProfileImage.tsx
+++ b/src/components/profile/ProfileImage.tsx
@@ -90,7 +90,7 @@ const ProfileImage = ({ profile }: ProfileImageProps) => {
                 type="file"
                 accept="image/*"
                 ref={fileInputRef}
-                className="feed-create-form-input__input"
+                className="blind"
                 onInput={onChangeUploadImageHandler}
               />
               사진 업데이트

--- a/src/components/user-block/UserBlockList.tsx
+++ b/src/components/user-block/UserBlockList.tsx
@@ -1,16 +1,15 @@
 import React from 'react';
 import UserBlockService from '@/services/user-block';
-import { UserBlockType } from '@/core';
 import UserBlockListItem from '@/components/user-block/UserBlockListItem';
 import InfinityDataList from '../common/InfinityDataList';
 
 const UserBlockList = () => {
   return (
-    <InfinityDataList<UserBlockType>
+    <InfinityDataList
       queryKey={['blockUsers']}
       listType={'button'}
       fetchData={(page) => UserBlockService.getBlockUsers({ page, limit: 5 })}
-      ChildCompoentToRender={UserBlockListItem}
+      renderToChildComponent={UserBlockListItem}
     ></InfinityDataList>
   );
 };

--- a/src/components/user-block/UserBlockListItem.tsx
+++ b/src/components/user-block/UserBlockListItem.tsx
@@ -55,7 +55,7 @@ const UserBlockListItem = ({ item }: UserBlockListItemProps) => {
             })
           }
         >
-          {isLoading ? <LoadingSpinner /> : <>차단 해제</>}
+          {isLoading ? <LoadingSpinner variant="white" /> : <>차단 해제</>}
         </Button>
       </div>
     </div>

--- a/src/pages/[username]/edit/index.tsx
+++ b/src/pages/[username]/edit/index.tsx
@@ -1,66 +1,33 @@
-import React, { FormEvent, useState } from 'react';
-import { useRecoilValue } from 'recoil';
+import React from 'react';
 import { useRouter } from 'next/router';
-import { useMutation } from '@tanstack/react-query';
-import {
-  CONST_GENDER,
-  GENDER,
-  UserType,
-  UserUpdateType,
-  genderTransformer,
-} from '@/core';
-import useForm from '@/hooks/useForm';
-// import LoadingLayer from '@/components/common/LoadingLayer';
-import Button from '@/components/common/Button';
-import ErrorMessage from '@/components/common/ErrorMessage';
-import ButtonGroup from '@/components/common/ButtonGroup';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import dynamic from 'next/dynamic';
+import { UserType } from '@/core';
 import UserService from '@/services/user';
-import { userState } from '@/store/userAtom';
 import TopHeader from '@/components/nav/topHeader/TopHeader';
-import ProfileImage from '@/components/profile/ProfileImage';
-import { AxiosErrorResponseType } from '@/core/types/error/axios-error-response.type';
+import useAuth from '@/hooks/useAuth';
+import ProfileEditForm from '@/components/profile/ProfileEditForm';
 
-const genderOptions: GENDER[] = [...CONST_GENDER];
+const LoadingLayer = dynamic(() => import('@/components/common/LoadingLayer'), {
+  ssr: false,
+});
 
 function ProfileEdit() {
-  const user = useRecoilValue<UserType | null>(userState);
-  const userInitialState = {
-    nickname: user?.nickname,
-    bio: user?.bio,
-    gender: user?.gender,
-  };
-  const { formData: userUpdate, onChange } =
-    useForm<UserUpdateType>(userInitialState);
-
+  const queryClient = useQueryClient();
   const router = useRouter();
-  const [errorMessage, setErrorMessage] = useState([]);
-
-  const { mutateAsync, isError } = useMutation(
-    (formData: UserUpdateType) => {
-      if (user?.id !== undefined) {
-        return UserService.updateUser(user.id, formData);
-      }
-      return Promise.reject(new Error('유저 정보를 불러오지 못했습니다'));
-    },
+  const { payload } = useAuth();
+  const { data: user, isLoading } = useQuery<UserType>(
+    [['user-edit', payload?.username]],
+    () => UserService.findUserByUsername(payload?.username as string),
     {
       onSuccess: () => {
-        router.back();
-      },
-      onError: (error: AxiosErrorResponseType) => {
-        if (error?.response?.status === 404) {
-          setErrorMessage(error?.response?.data.message);
-        }
+        queryClient.invalidateQueries(['user', router.query.username]);
+        queryClient.invalidateQueries(['user', payload?.username]);
       },
     },
   );
 
-  const onSubmitForm = async (
-    event: FormEvent<HTMLFormElement>,
-    formData: UserUpdateType,
-  ) => {
-    event.preventDefault();
-    await mutateAsync(formData);
-  };
+  if (isLoading) return <LoadingLayer />;
 
   return (
     <>
@@ -71,82 +38,11 @@ function ProfileEdit() {
         <TopHeader.Title>프로필 수정</TopHeader.Title>
         <TopHeader.Right></TopHeader.Right>
       </TopHeader>
-      <div className="profile-edit grid">
-        {/* {isLoading && <LoadingLayer />} */}
-        <div>
-          <div className="profile-info">
-            <h2 className="profile-info__title">{user?.username}</h2>
-            {user && <ProfileImage profile={user} />}
-          </div>
-          <div className="form-area">
-            <form
-              className="login-form"
-              onSubmit={(event) => onSubmitForm(event, userUpdate)}
-            >
-              <div className="form-group">
-                <div className="input-group">
-                  <div className="input-field">
-                    <input
-                      type="text"
-                      value={userUpdate.nickname}
-                      name="nickname"
-                      placeholder="닉네임"
-                      onChange={onChange}
-                    />
-                  </div>
-                </div>
-                <div className="input-group">
-                  <div className="input-field">
-                    <input
-                      type="text"
-                      value={userUpdate.bio}
-                      name="bio"
-                      placeholder="자기소개"
-                      onChange={onChange}
-                    />
-                  </div>
-                </div>
-                <div className="input-group">
-                  <div>
-                    <select
-                      name="gender"
-                      value={userUpdate.gender}
-                      onChange={onChange}
-                      className="select-box"
-                    >
-                      {genderOptions.map((option) => (
-                        <option
-                          key={option}
-                          value={option}
-                          className="select-option"
-                        >
-                          {genderTransformer(option)}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-                </div>
-              </div>
-              {isError && <ErrorMessage errorMessage={errorMessage} />}
-              <ButtonGroup>
-                <Button
-                  size="md"
-                  variant="primary"
-                  type="submit"
-                  isEnglish
-                  isFull
-                  isDisabled={
-                    JSON.stringify(userUpdate) ===
-                    JSON.stringify(userInitialState)
-                  }
-                >
-                  EDIT
-                </Button>
-              </ButtonGroup>
-            </form>
-          </div>
+      {user && (
+        <div className="profile-edit grid">
+          <ProfileEditForm profile={user} />
         </div>
-      </div>
+      )}
     </>
   );
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -13,7 +13,13 @@ import NoneLayout from '@/components/layouts/NoneLayout';
 import '@/styles/globals.scss';
 import useAuth from '@/hooks/useAuth';
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 0,
+    },
+  },
+});
 const routes = ['/', '/login', '/signup'];
 
 export default function App({ Component, pageProps }: AppProps) {

--- a/src/pages/explore/feed/tags/[tagName]/index.tsx
+++ b/src/pages/explore/feed/tags/[tagName]/index.tsx
@@ -25,8 +25,8 @@ const FeedTagName = () => {
         <div className="inner__container">
           <ExploreTagInfo />
           <div className="profile-feeds-list">
-            <InfinityDataList<FeedType>
-              queryKey={['feedByTags', router.query.tagName]}
+            <InfinityDataList
+              queryKey={['feedByTags', router.query.tagName as string]}
               listType={'scroll'}
               fetchData={(page) =>
                 FeedService.getFeeds({
@@ -36,8 +36,7 @@ const FeedTagName = () => {
                   viewerId: payload?._id,
                 })
               }
-              ChildCompoentToRender={ProfileFeedListItem}
-              propsObject={{ queryKey: ['feedByTags', router.query.tagName] }}
+              renderToChildComponent={ProfileFeedListItem}
             ></InfinityDataList>
           </div>
         </div>

--- a/src/pages/feed/[id]/comment/index.tsx
+++ b/src/pages/feed/[id]/comment/index.tsx
@@ -78,7 +78,7 @@ export default function CommentPage() {
               최신 순
             </button>
           </div>
-          <InfinityDataList<CommentType>
+          <InfinityDataList
             queryKey={['comments', router.query.id as string, orderBy]}
             listType={'scroll'}
             fetchData={(page, limit) =>
@@ -88,7 +88,7 @@ export default function CommentPage() {
                 orderBy,
               })
             }
-            ChildCompoentToRender={CommentItem}
+            renderToChildComponent={CommentItem}
           ></InfinityDataList>
         </div>
         <CommentInput />

--- a/src/styles/components/profile/_profile-info.scss
+++ b/src/styles/components/profile/_profile-info.scss
@@ -83,6 +83,8 @@
       text-align: center;
       margin-top: 1rem;
       color: rgba($color: white, $alpha: 0.6);
+      white-space: pre-line;
+      line-height: 1.6;
     }
   }
 


### PR DESCRIPTION
## 🐳 개요
프로필 수정 페이지 및 관련 컴포넌트 리팩토링

## 🐳 작업사항
- 프로필 페이지  
   - 새로고침 시에도 데이터 불러올수 있게 적용  
   - InputField , TextAreaField 컴포넌트 적용 및 css 수정
      ![image](https://github.com/PlaNet-Devteam/sns-project-client/assets/52031484/ede3bb34-1280-4293-89b5-cbad99c0dc98)

- InfinityDataList 컴포넌트 타입관련 리팩토링
- 페이지 이동시 피드 상세 모달 상태 초기화 
- QueryClient default retry 옵션 추가

## 🐳 공유사항
- retry 횟수를 0으로 지정하여 API 요청 실패시 바로 에러페이로 전환되게 수정