### PR TITLE
fix: 피드 Action Button 이벤트시 newFeeds query key 갱신

### DIFF
--- a/src/components/feed/FeedItemActionButtons.tsx
+++ b/src/components/feed/FeedItemActionButtons.tsx
@@ -47,6 +47,7 @@ const FeedItemActionButtons = ({ item }: FeedItemActionButtonsProps) => {
       queryClient.invalidateQueries(['feed-detail', String(item.id)]);
     } else {
       queryClient.invalidateQueries(['feeds']);
+      queryClient.invalidateQueries(['newFeeds']);
     }
   };
 

--- a/src/pages/feed/create/index.tsx
+++ b/src/pages/feed/create/index.tsx
@@ -69,8 +69,6 @@ function CreateFeed() {
     } catch (error) {
       console.error(error);
     }
-
-    console.log('imageList', imageList);
   };
 
   const onClickUploadImageHandler = async (
@@ -97,7 +95,6 @@ function CreateFeed() {
     }
 
     setImageList(imageUrlLists);
-    console.log(imageList);
   };
 
   const onClickRemoveImageHandler = (index: number) => {

--- a/src/pages/message/userlist/index.tsx
+++ b/src/pages/message/userlist/index.tsx
@@ -32,7 +32,6 @@ const UserList = () => {
   );
 
   socket.on('create_room', (data: string) => {
-    console.log(data);
     router.push(`/message/${data}`);
   });
   const myId = user?.id;

--- a/src/utils/uploadImage.ts
+++ b/src/utils/uploadImage.ts
@@ -20,8 +20,6 @@ export const uploadFile = (
   file: File,
   cate: string,
 ): Promise<string | void> => {
-  console.log('file', file);
-  console.log(s3);
   const params: AWS.S3.PutObjectRequest = {
     ACL: 'public-read',
     Body: file,
@@ -47,8 +45,7 @@ export const uploadFile = (
   };
 
   return uploadToS3()
-    .then((data) => {
-      console.log('upload Image', data);
+    .then(() => {
       return params.Key;
     })
     .catch((error) => {


### PR DESCRIPTION
## 🐳 개요
피드 Action Button 이벤트시 newFeeds query key 갱신

## 🐳 작업사항
-피드 목록에서 무한스크롤 후 불러오는 newFeeds 의 액션 이벤트 후 query key 갱신 

## 🐳 공유사항
```tsx
 const onSuccessInvalidateQueries = () => {
    if (isFeedModalOpen && feedModal) {
      queryClient.invalidateQueries(['feed-modal', feedModal.id]);
    } else if ((router.query.id as string) !== undefined) {
      queryClient.invalidateQueries(['feed-detail', String(item.id)]);
    } else {
      queryClient.invalidateQueries(['feeds']);
      queryClient.invalidateQueries(['newFeeds']);
    }
  };

```
