### PR TITLE
Fix: scroll location save bug

### DIFF
--- a/src/hooks/useIsScrolling.ts
+++ b/src/hooks/useIsScrolling.ts
@@ -3,15 +3,7 @@ import { useCallback, useEffect, useState } from 'react';
 export function useIsScrolling() {
   const [isScrolling, setIsScrolling] = useState(false);
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const handleScroll = () => {
-    if (!isScrolling) {
-      setIsScrolling(true);
-    }
-    ScrollDebounce();
-  };
-
-  const debounce = (callback: () => void, delay: number) => {
+  const debounce = useCallback((callback: () => void, delay: number) => {
     let timeout: NodeJS.Timeout;
 
     return () => {
@@ -20,19 +12,22 @@ export function useIsScrolling() {
         callback();
       }, delay);
     };
-  };
+  }, []);
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const ScrollDebounce = useCallback(
-    debounce(async () => {
-      try {
-        setIsScrolling(false);
-      } catch (error) {
-        console.error(error);
-      }
-    }, 500),
-    [isScrolling],
-  );
+  const ScrollDebounce = debounce(async () => {
+    try {
+      setIsScrolling(false);
+    } catch (error) {
+      console.error(error);
+    }
+  }, 500);
+
+  const handleScroll = useCallback(() => {
+    if (!isScrolling) {
+      setIsScrolling(true);
+    }
+    ScrollDebounce();
+  }, [isScrolling, ScrollDebounce]);
 
   useEffect(() => {
     window.addEventListener('scroll', handleScroll);

--- a/src/pages/feed/index.tsx
+++ b/src/pages/feed/index.tsx
@@ -11,6 +11,7 @@ import { InfinitePagesType } from '@/core/types/common';
 import LoadingSpinner from '@/components/common/LoadingSpinner';
 import LoadingSpinnerContainer from '@/components/common/LoadingSpinnerContainer';
 import EmptyData from '@/components/common/EmptyData';
+import { useScrollObserver } from '@/hooks/useObserver';
 import { useLocalStorage } from '../../hooks/useLocalStorage';
 
 const Feed = () => {
@@ -51,6 +52,8 @@ const Feed = () => {
         ))}
     </>
   );
+
+  useScrollObserver();
 
   return (
     <>


### PR DESCRIPTION
## 🐳 개요

feed 에서 클릭을 하지 않고 페이지 이동이 있을시, 스크롤 위치 저장이 안되는 버그 수정

## 🐳 작업사항

* router.events 를 사용해서 페이지 이동을 감지하고 스크롤 위치를 저장함

## 🐳 공유사항

* 저번주에 작업할 땐 제대로 작동하지 않았었는데, 이번주에 다시 확인하니 갑자기 잘 작동함 ( 페이지 이동을 하면 스크롤이 0으로  초기화 되어버렸음. 지금은 X ) 
테스트 부탁드립니다.
